### PR TITLE
Config flags

### DIFF
--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ChainSafe/chainbridge-core/config"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -53,4 +54,22 @@ func GetLastStoredBlock(db KeyValueReader, chainID uint8) (*big.Int, error) {
 	}
 	block := big.NewInt(0).SetBytes(v)
 	return block, nil
+}
+
+// SetupBlockstore queries the blockstore for the latest known block. If the latest block is
+// greater than config.StartBlock, then config.StartBlock is replaced with the latest known block.
+func SetupBlockstore(generalConfig *config.GeneralChainConfig, kvdb KeyValueReaderWriter, startBlock *big.Int) (*big.Int, error) {
+	latestBlock, err := GetLastStoredBlock(kvdb, *generalConfig.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	if !generalConfig.FreshStart {
+		if latestBlock.Cmp(startBlock) == 1 {
+			return latestBlock, nil
+		} else {
+			return startBlock, nil
+		}
+	}
+	return big.NewInt(0), nil
 }

--- a/chains/evm/chain.go
+++ b/chains/evm/chain.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 
 	"github.com/ChainSafe/chainbridge-core/blockstore"
+	"github.com/ChainSafe/chainbridge-core/config"
 	"github.com/ChainSafe/chainbridge-core/relayer"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rs/zerolog/log"
@@ -29,22 +30,48 @@ type EVMChain struct {
 	chainID               uint8
 	kvdb                  blockstore.KeyValueReaderWriter
 	bridgeContractAddress string
+	config                *config.SharedEVMConfig
 }
 
-func NewEVMChain(dr EventListener, writer ProposalVoter, kvdb blockstore.KeyValueReaderWriter, bridgeContractAddress string, chainID uint8) *EVMChain {
-	return &EVMChain{listener: dr, writer: writer, kvdb: kvdb, bridgeContractAddress: bridgeContractAddress, chainID: chainID}
+func NewEVMChain(dr EventListener, writer ProposalVoter, kvdb blockstore.KeyValueReaderWriter, bridgeContractAddress string, chainID uint8, config *config.SharedEVMConfig) *EVMChain {
+	return &EVMChain{
+		listener:              dr,
+		writer:                writer,
+		kvdb:                  kvdb,
+		bridgeContractAddress: bridgeContractAddress,
+		chainID:               chainID,
+		config:                config,
+	}
+}
+
+// setupBlockstore queries the blockstore for the latest known block. If the latest block is
+// greater than config.StartBlock, then config.StartBlock is replaced with the latest known block.
+func (c *EVMChain) setupBlockstore() error {
+	if !c.config.GeneralChainConfig.FreshStart {
+		latestBlock, err := blockstore.GetLastStoredBlock(c.kvdb, *c.config.GeneralChainConfig.Id)
+		if err != nil {
+			return err
+		}
+
+		if latestBlock.Cmp(c.config.StartBlock) == 1 {
+			c.config.StartBlock = latestBlock
+		}
+	}
+
+	return nil
 }
 
 // PollEvents is the goroutine that polling blocks and searching Deposit Events in them. Event then sent to eventsChan
 func (c *EVMChain) PollEvents(stop <-chan struct{}, sysErr chan<- error, eventsChan chan *relayer.Message) {
 	log.Info().Msg("Polling Blocks...")
 	// Handler chain specific configs and flags
-	b, err := blockstore.GetLastStoredBlock(c.kvdb, c.chainID)
+	//b, err := blockstore.GetLastStoredBlock(c.kvdb, c.chainID)
+	err := c.setupBlockstore()
 	if err != nil {
 		sysErr <- fmt.Errorf("error %w on getting last stored block", err)
 		return
 	}
-	ech := c.listener.ListenToEvents(b, c.chainID, c.bridgeContractAddress, c.kvdb, stop, sysErr)
+	ech := c.listener.ListenToEvents(c.config.StartBlock, c.chainID, c.bridgeContractAddress, c.kvdb, stop, sysErr)
 	for {
 		select {
 		case <-stop:

--- a/chains/evm/chain.go
+++ b/chains/evm/chain.go
@@ -44,34 +44,17 @@ func NewEVMChain(dr EventListener, writer ProposalVoter, kvdb blockstore.KeyValu
 	}
 }
 
-// setupBlockstore queries the blockstore for the latest known block. If the latest block is
-// greater than config.StartBlock, then config.StartBlock is replaced with the latest known block.
-func (c *EVMChain) setupBlockstore() error {
-	if !c.config.GeneralChainConfig.FreshStart {
-		latestBlock, err := blockstore.GetLastStoredBlock(c.kvdb, *c.config.GeneralChainConfig.Id)
-		if err != nil {
-			return err
-		}
-
-		if latestBlock.Cmp(c.config.StartBlock) == 1 {
-			c.config.StartBlock = latestBlock
-		}
-	}
-
-	return nil
-}
-
 // PollEvents is the goroutine that polling blocks and searching Deposit Events in them. Event then sent to eventsChan
 func (c *EVMChain) PollEvents(stop <-chan struct{}, sysErr chan<- error, eventsChan chan *relayer.Message) {
 	log.Info().Msg("Polling Blocks...")
 	// Handler chain specific configs and flags
 	//b, err := blockstore.GetLastStoredBlock(c.kvdb, c.chainID)
-	err := c.setupBlockstore()
+	block, err := blockstore.SetupBlockstore(&c.config.GeneralChainConfig, c.kvdb, c.config.StartBlock)
 	if err != nil {
 		sysErr <- fmt.Errorf("error %w on getting last stored block", err)
 		return
 	}
-	ech := c.listener.ListenToEvents(c.config.StartBlock, c.chainID, c.bridgeContractAddress, c.kvdb, stop, sysErr)
+	ech := c.listener.ListenToEvents(block, c.chainID, c.bridgeContractAddress, c.kvdb, stop, sysErr)
 	for {
 		select {
 		case <-stop:

--- a/chains/substrate/chain.go
+++ b/chains/substrate/chain.go
@@ -37,33 +37,16 @@ func NewSubstrateChain(listener EventListener, writer ProposalVoter, kvdb blocks
 	}
 }
 
-// setupBlockstore queries the blockstore for the latest known block. If the latest block is
-// greater than config.StartBlock, then config.StartBlock is replaced with the latest known block.
-func (c *SubstrateChain) setupBlockstore() error {
-	if !c.config.GeneralChainConfig.FreshStart {
-		latestBlock, err := blockstore.GetLastStoredBlock(c.kvdb, *c.config.GeneralChainConfig.Id)
-		if err != nil {
-			return err
-		}
-
-		if latestBlock.Cmp(c.config.StartBlock) == 1 {
-			c.config.StartBlock = latestBlock
-		}
-	}
-
-	return nil
-}
-
 func (c *SubstrateChain) PollEvents(stop <-chan struct{}, sysErr chan<- error, eventsChan chan *relayer.Message) {
 	log.Info().Msg("Polling Blocks...")
 	// Handler chain specific configs and flags
 	//b, err := blockstore.GetLastStoredBlock(c.kvdb, c.chainID)
-	err := c.setupBlockstore()
+	block, err := blockstore.SetupBlockstore(&c.config.GeneralChainConfig, c.kvdb, c.config.StartBlock)
 	if err != nil {
 		sysErr <- fmt.Errorf("error %w on getting last stored block", err)
 		return
 	}
-	ech := c.listener.ListenToEvents(c.config.StartBlock, c.chainID, c.kvdb, stop, sysErr)
+	ech := c.listener.ListenToEvents(block, c.chainID, c.kvdb, stop, sysErr)
 	for {
 		select {
 		case <-stop:

--- a/chains/substrate/chain.go
+++ b/chains/substrate/chain.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ChainSafe/chainbridge-core/blockstore"
+	"github.com/ChainSafe/chainbridge-core/config"
 	"github.com/ChainSafe/chainbridge-core/relayer"
 	"github.com/rs/zerolog/log"
 )
@@ -23,21 +24,46 @@ type SubstrateChain struct {
 	listener EventListener
 	writer   ProposalVoter
 	kvdb     blockstore.KeyValueReaderWriter
+	config   *config.SharedSubstrateConfig
 }
 
-func NewSubstrateChain(listener EventListener, writer ProposalVoter, kvdb blockstore.KeyValueReaderWriter, chainID uint8) *SubstrateChain {
-	return &SubstrateChain{listener: listener, writer: writer, kvdb: kvdb, chainID: chainID}
+func NewSubstrateChain(listener EventListener, writer ProposalVoter, kvdb blockstore.KeyValueReaderWriter, chainID uint8, config *config.SharedSubstrateConfig) *SubstrateChain {
+	return &SubstrateChain{
+		listener: listener,
+		writer:   writer,
+		kvdb:     kvdb,
+		chainID:  chainID,
+		config:   config,
+	}
+}
+
+// setupBlockstore queries the blockstore for the latest known block. If the latest block is
+// greater than config.StartBlock, then config.StartBlock is replaced with the latest known block.
+func (c *SubstrateChain) setupBlockstore() error {
+	if !c.config.GeneralChainConfig.FreshStart {
+		latestBlock, err := blockstore.GetLastStoredBlock(c.kvdb, *c.config.GeneralChainConfig.Id)
+		if err != nil {
+			return err
+		}
+
+		if latestBlock.Cmp(c.config.StartBlock) == 1 {
+			c.config.StartBlock = latestBlock
+		}
+	}
+
+	return nil
 }
 
 func (c *SubstrateChain) PollEvents(stop <-chan struct{}, sysErr chan<- error, eventsChan chan *relayer.Message) {
 	log.Info().Msg("Polling Blocks...")
 	// Handler chain specific configs and flags
-	b, err := blockstore.GetLastStoredBlock(c.kvdb, c.chainID)
+	//b, err := blockstore.GetLastStoredBlock(c.kvdb, c.chainID)
+	err := c.setupBlockstore()
 	if err != nil {
 		sysErr <- fmt.Errorf("error %w on getting last stored block", err)
 		return
 	}
-	ech := c.listener.ListenToEvents(b, c.chainID, c.kvdb, stop, sysErr)
+	ech := c.listener.ListenToEvents(c.config.StartBlock, c.chainID, c.kvdb, stop, sysErr)
 	for {
 		select {
 		case <-stop:

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type GeneralChainConfig struct {
 	Endpoint       string `mapstructure:"endpoint"`
 	From           string `mapstructure:"from"`
 	KeystorePath   string
+	Insecure       bool
 	BlockstorePath string
 	FreshStart     bool
 	LatestBlock    bool
@@ -41,8 +42,15 @@ func (c *GeneralChainConfig) Validate() error {
 }
 
 func (c *GeneralChainConfig) ParseConfig() {
-	c.KeystorePath = viper.GetString(KeystoreFlagName)
+
+	if path := viper.GetString(TestKeyFlagName); path != "" {
+		c.KeystorePath = path
+		c.Insecure = true
+	} else {
+		c.KeystorePath = viper.GetString(KeystoreFlagName)
+	}
 	c.BlockstorePath = viper.GetString(BlockstoreFlagName)
 	c.FreshStart = viper.GetBool(FreshStartFlagName)
 	c.LatestBlock = viper.GetBool(LatestBlockFlagName)
+
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,11 +6,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-const DefaultGasLimit = 6721975
-const DefaultGasPrice = 20000000000
-const DefaultGasMultiplier = 1
-const DefaultBlockConfirmations = 10
-
 type GeneralChainConfig struct {
 	Name           string `mapstructure:"name"`
 	Type           string `mapstructure:"type"`

--- a/config/evm.go
+++ b/config/evm.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"fmt"
+	"math/big"
+)
+
+type SharedEVMConfig struct {
+	GeneralChainConfig GeneralChainConfig
+	Bridge             string
+	Erc20Handler       string
+	Erc721Handler      string
+	GenericHandler     string
+	MaxGasPrice        *big.Int
+	GasMultiplier      *big.Float
+	GasLimit           *big.Int
+	Http               bool
+	StartBlock         *big.Int
+	BlockConfirmations *big.Int
+}
+
+type RawSharedEVMConfig struct {
+	GeneralChainConfig `mapstructure:",squash"`
+	Bridge             string  `mapstructure:"bridge"`
+	Erc20Handler       string  `mapstructure:"erc20Handler"`
+	Erc721Handler      string  `mapstructure:"erc721Handler"`
+	GenericHandler     string  `mapstructure:"genericHandler"`
+	MaxGasPrice        int64   `mapstructure:"maxGasPrice"`
+	GasMultiplier      float64 `mapstructure:"gasMultiplier"`
+	GasLimit           int64   `mapstructure:"gasLimit"`
+	Http               bool    `mapstructure:"http"`
+	StartBlock         int64   `mapstructure:"startBlock"`
+	BlockConfirmations int64   `mapstructure:"blockConfirmations"`
+}
+
+func (c *RawSharedEVMConfig) Validate() error {
+	if err := c.GeneralChainConfig.Validate(); err != nil {
+		return err
+	}
+	if c.Bridge == "" {
+		return fmt.Errorf("required field chain.Bridge empty for chain %v", *c.Id)
+	}
+	return nil
+}
+
+func (c *RawSharedEVMConfig) ParseConfig() (*SharedEVMConfig, error) {
+
+	c.GeneralChainConfig.ParseConfig()
+
+	// fmt.Println(c.GeneralChainConfig.KeystorePath)
+	// fmt.Println(c.GeneralChainConfig.BlockstorePath)
+	// fmt.Println(c.GeneralChainConfig.FreshStart)
+	// fmt.Println(c.GeneralChainConfig.LatestBlock)
+
+	config := &SharedEVMConfig{
+		GeneralChainConfig: c.GeneralChainConfig,
+		Erc20Handler:       c.Erc20Handler,
+		Erc721Handler:      c.Erc721Handler,
+		GenericHandler:     c.GenericHandler,
+		GasLimit:           big.NewInt(DefaultGasLimit),
+		MaxGasPrice:        big.NewInt(DefaultGasPrice),
+		GasMultiplier:      big.NewFloat(DefaultGasMultiplier),
+		Http:               c.Http,
+		StartBlock:         big.NewInt(c.StartBlock),
+		BlockConfirmations: big.NewInt(DefaultBlockConfirmations),
+	}
+
+	if c.Bridge != "" {
+		config.Bridge = c.Bridge
+	} else {
+		return nil, fmt.Errorf("must provide opts.bridge field for ethereum config")
+	}
+
+	if c.GasLimit != 0 {
+		config.GasLimit = big.NewInt(c.GasLimit)
+	}
+
+	if c.MaxGasPrice != 0 {
+		config.MaxGasPrice = big.NewInt(c.MaxGasPrice)
+	}
+
+	if c.GasMultiplier != 0 {
+		config.GasMultiplier = big.NewFloat(c.GasMultiplier)
+	}
+
+	if c.BlockConfirmations != 0 {
+		config.BlockConfirmations = big.NewInt(c.BlockConfirmations)
+	}
+
+	return config, nil
+}

--- a/config/evm.go
+++ b/config/evm.go
@@ -47,11 +47,6 @@ func (c *RawSharedEVMConfig) ParseConfig() (*SharedEVMConfig, error) {
 
 	c.GeneralChainConfig.ParseConfig()
 
-	// fmt.Println(c.GeneralChainConfig.KeystorePath)
-	// fmt.Println(c.GeneralChainConfig.BlockstorePath)
-	// fmt.Println(c.GeneralChainConfig.FreshStart)
-	// fmt.Println(c.GeneralChainConfig.LatestBlock)
-
 	config := &SharedEVMConfig{
 		GeneralChainConfig: c.GeneralChainConfig,
 		Erc20Handler:       c.Erc20Handler,

--- a/config/evm.go
+++ b/config/evm.go
@@ -5,6 +5,11 @@ import (
 	"math/big"
 )
 
+const DefaultGasLimit = 6721975
+const DefaultGasPrice = 20000000000
+const DefaultGasMultiplier = 1
+const DefaultBlockConfirmations = 10
+
 type SharedEVMConfig struct {
 	GeneralChainConfig GeneralChainConfig
 	Bridge             string

--- a/config/flags.go
+++ b/config/flags.go
@@ -1,6 +1,7 @@
 package config
 
 var (
+	ConfigFlagName      = "config"
 	KeystoreFlagName    = "keystore"
 	BlockstoreFlagName  = "blockstore"
 	FreshStartFlagName  = "fresh"

--- a/config/flags.go
+++ b/config/flags.go
@@ -1,0 +1,8 @@
+package config
+
+var (
+	KeystoreFlagName    = "keystore"
+	BlockstoreFlagName  = "blockstore"
+	FreshStartFlagName  = "fresh"
+	LatestBlockFlagName = "latest"
+)

--- a/config/flags.go
+++ b/config/flags.go
@@ -5,4 +5,5 @@ var (
 	BlockstoreFlagName  = "blockstore"
 	FreshStartFlagName  = "fresh"
 	LatestBlockFlagName = "latest"
+	TestKeyFlagName     = "testkey"
 )

--- a/config/substrate.go
+++ b/config/substrate.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"fmt"
+	"math/big"
+)
+
+type SharedSubstrateConfig struct {
+	GeneralChainConfig GeneralChainConfig
+	StartBlock         *big.Int
+	UseExtendedCall    bool
+}
+
+type RawSharedSubstrateConfig struct {
+	GeneralChainConfig `mapstructure:",squash"`
+	StartBlock         int64 `mapstructure:"startBlock"`
+	UseExtendedCall    bool  `mapstructure:"useExtendedCall"`
+}
+
+func (c *RawSharedSubstrateConfig) ParseConfig() *SharedSubstrateConfig {
+
+	c.GeneralChainConfig.ParseConfig()
+
+	fmt.Println(c.GeneralChainConfig.KeystorePath)
+	fmt.Println(c.GeneralChainConfig.BlockstorePath)
+	fmt.Println(c.GeneralChainConfig.FreshStart)
+	fmt.Println(c.GeneralChainConfig.LatestBlock)
+
+	config := &SharedSubstrateConfig{
+		GeneralChainConfig: c.GeneralChainConfig,
+		StartBlock:         big.NewInt(c.StartBlock),
+		UseExtendedCall:    c.UseExtendedCall,
+	}
+	return config
+}

--- a/config/substrate.go
+++ b/config/substrate.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"math/big"
 )
 
@@ -20,11 +19,6 @@ type RawSharedSubstrateConfig struct {
 func (c *RawSharedSubstrateConfig) ParseConfig() *SharedSubstrateConfig {
 
 	c.GeneralChainConfig.ParseConfig()
-
-	fmt.Println(c.GeneralChainConfig.KeystorePath)
-	fmt.Println(c.GeneralChainConfig.BlockstorePath)
-	fmt.Println(c.GeneralChainConfig.FreshStart)
-	fmt.Println(c.GeneralChainConfig.LatestBlock)
 
 	config := &SharedSubstrateConfig{
 		GeneralChainConfig: c.GeneralChainConfig,

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/rs/zerolog v1.21.0
 	github.com/spf13/viper v1.7.1
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
-	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,6 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190909091759-094676da4a83/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 h1:DZhuSZLsGlFL4CmhA8BcRA0mnthyA/nZ00AqCUo7vHg=
-golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -481,8 +479,8 @@ golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -529,6 +527,7 @@ golang.org/x/sys v0.0.0-20210105210732-16f7687f5001/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/keystore/decrypt.go
+++ b/keystore/decrypt.go
@@ -1,0 +1,95 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package keystore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/ChainSafe/chainbridge-core/crypto"
+	"github.com/ChainSafe/chainbridge-core/crypto/secp256k1"
+	"github.com/ChainSafe/chainbridge-core/crypto/sr25519"
+)
+
+// Decrypt uses AES to decrypt ciphertext with the symmetric key deterministically created from `password`
+func Decrypt(data, password []byte) ([]byte, error) {
+	gcm, err := gcmFromPassphrase(password)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		if err.Error() == "cipher: message authentication failed" {
+			err = errors.New(err.Error() + ". Incorrect Password.")
+		}
+		return nil, err
+	}
+
+	return plaintext, nil
+}
+
+// DecodeKeypair turns input bytes into a keypair based on the specified key type
+func DecodeKeypair(in []byte, keytype crypto.KeyType) (kp crypto.Keypair, err error) {
+	if keytype == crypto.Secp256k1Type {
+		kp = &secp256k1.Keypair{}
+		err = kp.Decode(in)
+	} else if keytype == crypto.Sr25519Type {
+		kp = &sr25519.Keypair{}
+		err = kp.Decode(in)
+	} else {
+		return nil, errors.New("cannot decode key: invalid key type")
+	}
+
+	return kp, err
+}
+
+// DecryptPrivateKey uses AES to decrypt the ciphertext into a `crypto.PrivateKey` with a symmetric key deterministically
+// created from `password`
+func DecryptKeypair(expectedPubK string, data, password []byte, keytype string) (crypto.Keypair, error) {
+	pk, err := Decrypt(data, password)
+	if err != nil {
+		return nil, err
+	}
+	kp, err := DecodeKeypair(pk, keytype)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that the decoding matches what was expected
+	if kp.PublicKey() != expectedPubK {
+		return nil, fmt.Errorf("unexpected key file data, file may be corrupt or have been tampered with")
+	}
+	return kp, nil
+}
+
+// ReadFromFileAndDecrypt reads ciphertext from a file and decrypts it using the password into a `crypto.PrivateKey`
+func ReadFromFileAndDecrypt(filename string, password []byte, keytype string) (crypto.Keypair, error) {
+	fp, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := ioutil.ReadFile(filepath.Clean(fp))
+	if err != nil {
+		return nil, err
+	}
+
+	keydata := new(EncryptedKeystore)
+	err = json.Unmarshal(data, keydata)
+	if err != nil {
+		return nil, err
+	}
+
+	if keytype != keydata.Type {
+		return nil, fmt.Errorf("Keystore type and Chain type mismatched. Expected Keystore file of type %s, got type %s", keytype, keydata.Type)
+	}
+
+	return DecryptKeypair(keydata.PublicKey, keydata.Ciphertext, password, keydata.Type)
+}

--- a/keystore/encrypt.go
+++ b/keystore/encrypt.go
@@ -1,0 +1,120 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package keystore
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+
+	"github.com/ChainSafe/chainbridge-core/crypto"
+	"github.com/ChainSafe/chainbridge-core/crypto/secp256k1"
+	sr25519 "github.com/ChainSafe/chainbridge-core/crypto/sr25519"
+	"golang.org/x/crypto/blake2b"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+type EncryptedKeystore struct {
+	Type       string `json:"type"`
+	PublicKey  string `json:"publicKey"`
+	Address    string `json:"address"`
+	Ciphertext []byte `json:"ciphertext"`
+}
+
+// gcmFromPassphrase creates a symmetric AES key given a password
+func gcmFromPassphrase(password []byte) (cipher.AEAD, error) {
+	hash := blake2b.Sum256(password)
+
+	block, err := aes.NewCipher(hash[:])
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	return gcm, nil
+}
+
+// Encrypt uses AES to encrypt `msg` with the symmetric key deterministically created from `password`
+func Encrypt(msg, password []byte) ([]byte, error) {
+	gcm, err := gcmFromPassphrase(password)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, msg, nil)
+	return ciphertext, nil
+}
+
+// EncryptKeypair uses AES to encrypt an encoded `crypto.Keypair` with a symmetric key deterministically
+// created from `password`
+func EncryptKeypair(kp crypto.Keypair, password []byte) ([]byte, error) {
+	return Encrypt(kp.Encode(), password)
+}
+
+// EncryptAndWriteToFile encrypts the `crypto.PrivateKey` using the password and saves it to the specified file
+func EncryptAndWriteToFile(file *os.File, kp crypto.Keypair, password []byte) error {
+	ciphertext, err := EncryptKeypair(kp, password)
+	if err != nil {
+		return err
+	}
+
+	keytype := ""
+
+	if _, ok := kp.(*sr25519.Keypair); ok {
+		keytype = crypto.Sr25519Type
+	}
+
+	if _, ok := kp.(*secp256k1.Keypair); ok {
+		keytype = crypto.Secp256k1Type
+	}
+
+	if keytype == "" {
+		return errors.New("cannot write key not of type secp256k1 or sr25519")
+	}
+
+	keydata := &EncryptedKeystore{
+		Type:       keytype,
+		PublicKey:  kp.PublicKey(),
+		Address:    kp.Address(),
+		Ciphertext: ciphertext,
+	}
+
+	data, err := json.MarshalIndent(keydata, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	_, err = file.Write(append(data, byte('\n')))
+	return err
+}
+
+// prompt user to enter password for encrypted keystore
+func GetPassword(msg string) []byte {
+	for {
+		fmt.Println(msg)
+		fmt.Print("> ")
+		password, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			fmt.Printf("invalid input: %s\n", err)
+		} else {
+			fmt.Printf("\n")
+			return password
+		}
+	}
+}

--- a/keystore/encrypt_test.go
+++ b/keystore/encrypt_test.go
@@ -1,0 +1,151 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package keystore
+
+import (
+	"bytes"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/ChainSafe/chainbridge-core/crypto/secp256k1"
+	"github.com/ChainSafe/chainbridge-core/crypto/sr25519"
+)
+
+func TestEncryptAndDecrypt(t *testing.T) {
+	password := []byte("noot")
+	msg := []byte("helloworld")
+
+	ciphertext, err := Encrypt(msg, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Decrypt(ciphertext, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(msg, res) {
+		t.Fatalf("Fail to decrypt: got %x expected %x", res, msg)
+	}
+}
+
+func TestEncryptAndDecryptKeypair(t *testing.T) {
+	buf := make([]byte, 32)
+	_, err := rand.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kp, err := secp256k1.NewKeypairFromPrivateKey(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	password := []byte("noot")
+
+	data, err := EncryptKeypair(kp, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := DecryptKeypair(kp.PublicKey(), data, password, "secp256k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(kp, res) {
+		t.Fatalf("Fail: got %#v expected %#v", res, kp)
+	}
+}
+
+func createTestFile(t *testing.T) (*os.File, string) {
+	filename := "./test_key"
+
+	fp, err := filepath.Abs(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := os.Create(fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return file, fp
+}
+
+func TestEncryptAndDecryptFromFile_Secp256k1(t *testing.T) {
+	password := []byte("noot")
+	file, fp := createTestFile(t)
+	defer os.Remove(fp)
+
+	kp, err := secp256k1.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = EncryptAndWriteToFile(file, kp, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ReadFromFileAndDecrypt(fp, password, "secp256k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(kp.Encode(), res.Encode()) {
+		t.Fatalf("Fail: got %#v expected %#v", res, kp)
+	}
+}
+
+func TestEncryptAndDecryptFromFile_Sr25519(t *testing.T) {
+	password := []byte("ansermino")
+	file, fp := createTestFile(t)
+	defer os.Remove(fp)
+
+	kp, err := sr25519.NewKeypairFromSeed("//seed", "substrate")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = EncryptAndWriteToFile(file, kp, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ReadFromFileAndDecrypt(fp, password, "sr25519")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(kp.Encode(), res.Encode()) {
+		t.Fatalf("Fail: got %#v expected %#v", res, kp)
+	}
+}
+
+func TestDecryptIncorrectType(t *testing.T) {
+	password := []byte("ansermino")
+	file, fp := createTestFile(t)
+	defer os.Remove(fp)
+
+	kp, err := sr25519.NewKeypairFromSeed("//seed", "substrate")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = EncryptAndWriteToFile(file, kp, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ReadFromFileAndDecrypt(fp, password, "secp256k1")
+	if err == nil {
+		t.Fatal("Expected mismatch error, got none.")
+	}
+}

--- a/keystore/keyring.go
+++ b/keystore/keyring.go
@@ -1,0 +1,120 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package keystore
+
+import (
+	"fmt"
+
+	"github.com/ChainSafe/chainbridge-core/crypto"
+	"github.com/ChainSafe/chainbridge-core/crypto/secp256k1"
+	"github.com/ChainSafe/chainbridge-core/crypto/sr25519"
+	"github.com/centrifuge/go-substrate-rpc-client/signature"
+)
+
+// The Constant "keys". These are the name that the keys are based on. This can be expanded, but
+// any additions must be added to Keys and to insecureKeyFromAddress
+const AliceKey = "alice"
+const BobKey = "bob"
+const CharlieKey = "charlie"
+const DaveKey = "dave"
+const EveKey = "eve"
+
+var Keys = []string{AliceKey, BobKey, CharlieKey, DaveKey, EveKey}
+
+// The Chain type Constants
+const EthChain = "ethereum"
+const SubChain = "substrate"
+
+var TestKeyRing *TestKeyRingHolder
+
+var AliceSr25519 = sr25519.NewKeypairFromKRP(signature.KeyringPair{
+	URI:       "//Alice",
+	Address:   "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+	PublicKey: []byte{0xd4, 0x35, 0x93, 0xc7, 0x15, 0xfd, 0xd3, 0x1c, 0x61, 0x14, 0x1a, 0xbd, 0x4, 0xa9, 0x9f, 0xd6, 0x82, 0x2c, 0x85, 0x58, 0x85, 0x4c, 0xcd, 0xe3, 0x9a, 0x56, 0x84, 0xe7, 0xa5, 0x6d, 0xa2, 0x7d},
+})
+
+var BobSr25519 = sr25519.NewKeypairFromKRP(signature.KeyringPair{
+	URI:       "//Bob",
+	Address:   "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+	PublicKey: []byte{0x8e, 0xaf, 0x4, 0x15, 0x16, 0x87, 0x73, 0x63, 0x26, 0xc9, 0xfe, 0xa1, 0x7e, 0x25, 0xfc, 0x52, 0x87, 0x61, 0x36, 0x93, 0xc9, 0x12, 0x90, 0x9c, 0xb2, 0x26, 0xaa, 0x47, 0x94, 0xf2, 0x6a, 0x48},
+})
+
+var CharlieSr25519 = sr25519.NewKeypairFromKRP(signature.KeyringPair{
+	URI:       "//Charlie",
+	Address:   "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
+	PublicKey: []byte{0x90, 0xb5, 0xab, 0x20, 0x5c, 0x69, 0x74, 0xc9, 0xea, 0x84, 0x1b, 0xe6, 0x88, 0x86, 0x46, 0x33, 0xdc, 0x9c, 0xa8, 0xa3, 0x57, 0x84, 0x3e, 0xea, 0xcf, 0x23, 0x14, 0x64, 0x99, 0x65, 0xfe, 0x22},
+})
+
+var DaveSr25519 = sr25519.NewKeypairFromKRP(signature.KeyringPair{
+	URI:       "//Dave",
+	Address:   "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+	PublicKey: []byte{0x30, 0x67, 0x21, 0x21, 0x1d, 0x54, 0x4, 0xbd, 0x9d, 0xa8, 0x8e, 0x2, 0x4, 0x36, 0xa, 0x1a, 0x9a, 0xb8, 0xb8, 0x7c, 0x66, 0xc1, 0xbc, 0x2f, 0xcd, 0xd3, 0x7f, 0x3c, 0x22, 0x22, 0xcc, 0x20},
+})
+
+var EveSr25519 = sr25519.NewKeypairFromKRP(signature.KeyringPair{
+	URI:       "//Eve",
+	Address:   "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw",
+	PublicKey: []byte{0xe6, 0x59, 0xa7, 0xa1, 0x62, 0x8c, 0xdd, 0x93, 0xfe, 0xbc, 0x4, 0xa4, 0xe0, 0x64, 0x6e, 0xa2, 0xe, 0x9f, 0x5f, 0xc, 0xe0, 0x97, 0xd9, 0xa0, 0x52, 0x90, 0xd4, 0xa9, 0xe0, 0x54, 0xdf, 0x4e},
+})
+
+// TestKeyStore is a struct that holds a Keystore of all the test keys
+type TestKeyRingHolder struct {
+	EthereumKeys  map[string]*secp256k1.Keypair
+	SubstrateKeys map[string]*sr25519.Keypair
+}
+
+// Init function to create a keyRing that can be accessed anywhere without having to recreate the data
+func init() {
+	TestKeyRing = &TestKeyRingHolder{
+		EthereumKeys: makeEthRing(),
+		SubstrateKeys: map[string]*sr25519.Keypair{
+			AliceKey:   AliceSr25519,
+			BobKey:     BobSr25519,
+			CharlieKey: CharlieSr25519,
+			DaveKey:    DaveSr25519,
+			EveKey:     EveSr25519,
+		},
+	}
+
+}
+
+func makeEthRing() map[string]*secp256k1.Keypair {
+	ring := map[string]*secp256k1.Keypair{}
+	for _, key := range Keys {
+		bz := padWithZeros([]byte(key), secp256k1.PrivateKeyLength)
+		kp, err := secp256k1.NewKeypairFromPrivateKey(bz)
+		if err != nil {
+			panic(err)
+		}
+		ring[key] = kp
+	}
+
+	return ring
+}
+
+// padWithZeros adds on extra 0 bytes to make a byte array of a specified length
+func padWithZeros(key []byte, targetLength int) []byte {
+	res := make([]byte, targetLength-len(key))
+	return append(res, key...)
+}
+
+// insecureKeypairFromAddress is used for resolving addresses to test keypairs.
+func insecureKeypairFromAddress(key string, chainType string) (crypto.Keypair, error) {
+	var kp crypto.Keypair
+	var ok bool
+
+	if chainType == EthChain {
+		kp, ok = TestKeyRing.EthereumKeys[key]
+	} else if chainType == SubChain {
+		kp, ok = TestKeyRing.SubstrateKeys[key]
+	} else {
+		return nil, fmt.Errorf("unrecognized chain type: %s", chainType)
+	}
+
+	if !ok {
+		return nil, fmt.Errorf("invalid test key selection: %s", key)
+	}
+
+	return kp, nil
+}

--- a/keystore/keyring_test.go
+++ b/keystore/keyring_test.go
@@ -1,0 +1,39 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package keystore
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestByteLength(t *testing.T) {
+	res := padWithZeros([]byte("Alice"), 32)
+
+	exp := append([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, []byte("Alice")...)
+	if !bytes.Equal(exp, res) {
+		t.Fatalf("Fail. Got: %#v\n\tExpected: %#v\n", res, exp)
+	}
+}
+func TestInsecureAddresses(t *testing.T) {
+	tkp, err := insecureKeypairFromAddress(AliceKey, EthChain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(tkp, TestKeyRing.EthereumKeys[AliceKey]) {
+		t.Fatalf("Key is not being returned correctly")
+	}
+
+	tkp, err = insecureKeypairFromAddress(AliceKey, SubChain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(tkp, TestKeyRing.SubstrateKeys[AliceKey]) {
+		t.Fatalf("Key is not being returned correctly")
+	}
+
+}

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -1,0 +1,67 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/*
+The keystore package is used to load keys from keystore files, both for live use and for testing.
+
+The Keystore
+
+The keystore file is used as a file representation of a key. It contains 4 parts:
+- The key type (secp256k1, sr25519)
+- The PublicKey
+- The Address
+- The ciphertext
+
+This keystore also requires a password to decrypt into a usable key.
+The keystore library can be used to both encrypt keys into keystores, and decrypt keystore into keys.
+For more information on how to encrypt and decrypt from the command line, reference the README: https://github.com/ChainSafe/ChainBridge
+
+The Keyring
+
+The keyring provides predefined secp256k1 and srr25519 keys to use in testing.
+These keys are automatically provided during runtime and stored in memory rather than being stored on disk.
+There are 5 keys currenty supported: Alice, Bob, Charlie, Dave, and Eve.
+
+*/
+package keystore
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ChainSafe/chainbridge-core/crypto"
+)
+
+const EnvPassword = "KEYSTORE_PASSWORD"
+
+var keyMapping = map[string]string{
+	"ethereum":  "secp256k1",
+	"substrate": "sr25519",
+}
+
+// KeypairFromAddress attempts to load the encrypted key file for the provided address,
+// prompting the user for the password.
+func KeypairFromAddress(addr, chainType, path string, insecure bool) (crypto.Keypair, error) {
+	if insecure {
+		return insecureKeypairFromAddress(path, chainType)
+	}
+	path = fmt.Sprintf("%s/%s.key", path, addr)
+	// Make sure key exists before prompting password
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, fmt.Errorf("key file not found: %s", path)
+	}
+
+	var pswd []byte
+	if pswdStr := os.Getenv(EnvPassword); pswdStr != "" {
+		pswd = []byte(pswdStr)
+	} else {
+		pswd = GetPassword(fmt.Sprintf("Enter password for key %s:", path))
+	}
+
+	kp, err := ReadFromFileAndDecrypt(path, pswd, keyMapping[chainType])
+	if err != nil {
+		return nil, err
+	}
+
+	return kp, nil
+}


### PR DESCRIPTION
## Changes
The majority of the changes for the initial flag work has been done inside the core. This is due to the current flags that have been integrated are global for all chains. The same way that the nested `GeneralConfigStruct` had a method `Validate` that was called upon by the client's, `GeneralConfigStruct` now has a `ParseConfig` method as well. Currently all `ParseConfig` does for `GeneralConfigStruct` is parse viper flags. At the moment the general config does not require any additional type transforms like the `SharedRawEVMConfig` or `SharedRawSubstrateConfig`, but if that becomes the case there is a place for it. 

A major change was having the `EVMChain` and `SubstrateChain` methods recognize the config of the clients used to initialize their writer and listener. I thought of having having adding a method to the existing interfaces that allowed for grabbing the general config but seemed to cause redundancy either among the interfaces or within the client modules. I settled on passing in the shared version of each type of config to the respective Chain structs. For this reason I also had to alter the substrate module to use the `SharedSubstrateConfig` as the EVM modules (eth and celo) already are doing with the `SharedEVMConfig`, although there aren't any additional config fields that the substrate module uses.

The code is still a little rough around the edges and I left a few TODOs within this repo and the `chainbridge-core-example`. Currently, the flags are also bound to viper within the `chainbridge-core-example`. This could possibly be moved into a method in the core package that is then called upon in the core example.

## Testing

Passing the correct flags does start the bridge. And the flags for fresh and latest work correctly for restarting the bridge. This perhaps should be unit tested though.

Closes: #6 

The usage of these changes is under this repository PR:
https://github.com/vezenovm/chainbridge-core-example/pull/1

Client module PRs:
https://github.com/ChainSafe/chainbridge-eth-module/pull/8
https://github.com/ChainSafe/chainbridge-substrate-module/pull/2
