### PR TITLE
Refactor pause/unpause calls to add unit tests

### DIFF
--- a/chains/evm/calls/bridge.go
+++ b/chains/evm/calls/bridge.go
@@ -402,16 +402,26 @@ func Withdraw(client ClientDispatcher, txFabric TxFabric, gasPricer GasPricer, g
 	return &h, nil
 }
 
+// PreparePauseInput generates bytedata for adminPauseTransfers contract method
+func PreparePauseInput() ([]byte, error) {
+	a, err := abi.JSON(strings.NewReader(consts.BridgeABI))
+	if err != nil {
+		return []byte{}, err
+	}
+
+	input, err := a.Pack("adminPauseTransfers")
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return input, nil
+}
+
 // Pause pauses: deposits, deposit executions, proposal creations,
 // and voting executions
 // https://github.com/ChainSafe/chainbridge-solidity/blob/master/contracts/Bridge.sol#L159-L165
 func Pause(client ClientDispatcher, txFabric TxFabric, gasPricer GasPricer, gasLimit uint64, bridgeAddress common.Address) (*common.Hash, error) {
-	a, err := abi.JSON(strings.NewReader(consts.BridgeABI))
-	if err != nil {
-		return nil, fmt.Errorf("could not parse bridge ABI: %w", err)
-	}
-
-	pauseInput, err := a.Pack("adminPauseTransfers")
+	pauseInput, err := PreparePauseInput()
 	if err != nil {
 		return nil, fmt.Errorf("could not prepare adminPauseTransfers input: %w", err)
 	}
@@ -433,16 +443,27 @@ func Pause(client ClientDispatcher, txFabric TxFabric, gasPricer GasPricer, gasL
 	return &h, nil
 }
 
+// PrepareUnpauseInput generates bytedata for adminUnpauseTransfers contract
+// method
+func PrepareUnpauseInput() ([]byte, error) {
+	a, err := abi.JSON(strings.NewReader(consts.BridgeABI))
+	if err != nil {
+		return []byte{}, err
+	}
+
+	input, err := a.Pack("adminUnpauseTransfers")
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return input, nil
+}
+
 // Unpause unpauses: deposits, deposit executions, proposal creations,
 // and voting executions
 // https://github.com/ChainSafe/chainbridge-solidity/blob/master/contracts/Bridge.sol#L167-L173
 func Unpause(client ClientDispatcher, txFabric TxFabric, gasPricer GasPricer, gasLimit uint64, bridgeAddress common.Address) (*common.Hash, error) {
-	a, err := abi.JSON(strings.NewReader(consts.BridgeABI))
-	if err != nil {
-		return nil, fmt.Errorf("could not parse bridge ABI: %w", err)
-	}
-
-	unpauseInput, err := a.Pack("adminUnpauseTransfers")
+	unpauseInput, err := PrepareUnpauseInput()
 	if err != nil {
 		return nil, fmt.Errorf("could not prepare adminUnpauseTransfers input: %w", err)
 	}

--- a/chains/evm/calls/bridge_test.go
+++ b/chains/evm/calls/bridge_test.go
@@ -95,3 +95,25 @@ func TestPrepareWithdrawInput(t *testing.T) {
 		t.Fatal("prepared input byte slice empty")
 	}
 }
+
+func TestPreparePauseInput(t *testing.T) {
+	inputBytes, err := calls.PreparePauseInput()
+	if err != nil {
+		t.Fatalf("could not prepare pause input: %v", err)
+	}
+
+	if len(inputBytes) == 0 {
+		t.Fatal("prepared input byte slice empty")
+	}
+}
+
+func TestPrepareUnpauseInput(t *testing.T) {
+	inputBytes, err := calls.PrepareUnpauseInput()
+	if err != nil {
+		t.Fatalf("could not prepare unpause input: %v", err)
+	}
+
+	if len(inputBytes) == 0 {
+		t.Fatal("prepared input byte slice empty")
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR breaks up the `Pause` and `Unpause` functions within the `calls` package in order to make the functions more unit testable, which also lends itself to improving overall test coverage.

The unit tests themselves are extremely basic, and just make sure that the contract method names are able to be packed without resulting in an empty byte slice since the prepare functions (and contract methods) take no arguments.

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: N/A

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
