### PR TITLE
Configurable logger

### DIFF
--- a/chains/evm/cli/logger/logger.go
+++ b/chains/evm/cli/logger/logger.go
@@ -2,10 +2,10 @@ package logger
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"time"
 
+	"github.com/ChainSafe/chainbridge-core/logger"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/pflag"
@@ -40,10 +40,8 @@ func LoggerMetadata(cmdName string, flagSet *pflag.FlagSet) {
 		log.Error().Err(fmt.Errorf("failed to write to log file: %v", err))
 	}
 
-	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	// PartsExclude - omit log level and execution time from final log
 	logConsoleWriter := zerolog.ConsoleWriter{Out: os.Stdout, PartsExclude: []string{"level", "time"}}
 	logFileWriter := zerolog.ConsoleWriter{Out: file, PartsExclude: []string{"level", "time"}}
-	mw := io.MultiWriter(logConsoleWriter, logFileWriter)
-	log.Logger = zerolog.New(mw).With().Timestamp().Logger()
+	logger.ConfigureLogger(zerolog.DebugLevel, logConsoleWriter, logFileWriter)
 }

--- a/config/relayer/config.go
+++ b/config/relayer/config.go
@@ -1,9 +1,43 @@
 package relayer
 
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+)
+
 type RelayerConfig struct {
-	OpenTelemetryCollectorURL string `mapstructure:"OpenTelemetryCollectorURL"`
+	OpenTelemetryCollectorURL string
+	LogLevel                  zerolog.Level
+	LogFile                   string
 }
 
-func (c *RelayerConfig) Validate() error {
+type RawRelayerConfig struct {
+	OpenTelemetryCollectorURL string `mapstructure:"OpenTelemetryCollectorURL" json:"opentelemetryCollectorURL"`
+	LogLevel                  string `mapstructure:"LogLevel" json:"logLevel"`
+	LogFile                   string `mapstructure:"LogFile" json:"logFile"`
+}
+
+func (c *RawRelayerConfig) Validate() error {
 	return nil
+}
+
+// NewRelayerConfig parses RawRelayerConfig into RelayerConfig
+func NewRelayerConfig(rawConfig RawRelayerConfig) (RelayerConfig, error) {
+	config := RelayerConfig{}
+	err := rawConfig.Validate()
+	if err != nil {
+		return config, err
+	}
+
+	logLevel, err := zerolog.ParseLevel(rawConfig.LogLevel)
+	if err != nil {
+		return config, fmt.Errorf("Unknown log level: %s", rawConfig.LogLevel)
+	}
+	config.LogLevel = logLevel
+
+	config.LogFile = rawConfig.LogFile
+	config.OpenTelemetryCollectorURL = rawConfig.OpenTelemetryCollectorURL
+
+	return config, nil
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,14 @@
+package logger
+
+import (
+	"io"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func ConfigureLogger(l zerolog.Level, writers ...io.Writer) {
+	zerolog.SetGlobalLevel(l)
+	mw := io.MultiWriter(writers...)
+	log.Logger = zerolog.New(mw).With().Timestamp().Logger()
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -7,6 +7,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// ConfigureLogger configures logger level and assigns an array
+// of writers for logger to write to
 func ConfigureLogger(l zerolog.Level, writers ...io.Writer) {
 	zerolog.SetGlobalLevel(l)
 	mw := io.MultiWriter(writers...)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- add ability to configure logger level and writers.
- add logLevel and logFile fields to relayer config.
- separate raw relayer config from parsed one

Decided to just add the ability to configure logger instead of add some custom exporters (file, datadog...) as
datadog agent also reads from file, opentelemtry collector will do that in the future and configuring zerolog to write to file
is just:

```go
	file, err := os.OpenFile(config.RelayerConfig.LogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
	if err != nil {
		panic(err)
	}
	logger.ConfigureLogger(config.RelayerConfig.LogLevel, file)
```

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #187 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
