### PR TITLE
Optimism Config

### DIFF
--- a/config/chain/evm.go
+++ b/config/chain/evm.go
@@ -50,19 +50,7 @@ func (c *RawEVMConfig) Validate() error {
 	return nil
 }
 
-// NewEVMConfig decodes and validates an instance of an EVMConfig from
-// raw chain config
-func NewEVMConfig(chainConfig map[string]interface{}) (*EVMConfig, error) {
-	var c RawEVMConfig
-	err := mapstructure.Decode(chainConfig, &c)
-	if err != nil {
-		return nil, err
-	}
-
-	err = c.Validate()
-	if err != nil {
-		return nil, err
-	}
+func (c *RawEVMConfig) ParseConfig() (*EVMConfig, error) {
 
 	c.GeneralChainConfig.ParseFlags()
 	config := &EVMConfig{
@@ -78,26 +66,43 @@ func NewEVMConfig(chainConfig map[string]interface{}) (*EVMConfig, error) {
 		StartBlock:         big.NewInt(c.StartBlock),
 		BlockConfirmations: big.NewInt(consts.DefaultBlockConfirmations),
 	}
-
 	if c.GasLimit != 0 {
 		config.GasLimit = big.NewInt(c.GasLimit)
 	}
-
 	if c.MaxGasPrice != 0 {
 		config.MaxGasPrice = big.NewInt(c.MaxGasPrice)
 	}
-
 	if c.GasMultiplier != 0 {
 		config.GasMultiplier = big.NewFloat(c.GasMultiplier)
 	}
-
 	if c.BlockConfirmations != 0 {
 		config.BlockConfirmations = big.NewInt(c.BlockConfirmations)
 	}
-
 	if c.BlockRetryInterval != 0 {
 		config.BlockRetryInterval = time.Duration(c.BlockRetryInterval) * time.Second
 	}
 
 	return config, nil
+}
+
+// NewEVMConfig decodes and validates an instance of an EVMConfig from
+// raw chain config
+func NewEVMConfig(chainConfig map[string]interface{}) (*EVMConfig, error) {
+	var c RawEVMConfig
+	err := mapstructure.Decode(chainConfig, &c)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	newCfg, err := c.ParseConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return newCfg, nil
 }

--- a/config/chain/optimism.go
+++ b/config/chain/optimism.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"github.com/mitchellh/mapstructure"
-	"github.com/rs/zerolog/log"
 )
 
 const DefaultGasLimit = 6721975
@@ -32,13 +31,12 @@ func (c *RawOptimismConfig) Validate() error {
 // NewOptimismConfig decodes and validates an instance of an OptimismConfig from
 // raw chain config
 func NewOptimismConfig(chainConfig map[string]interface{}) (*OptimismConfig, error) {
-	log.Debug().Msg("got into optimism config")
 	var c RawOptimismConfig
 	err := mapstructure.Decode(chainConfig, &c)
 	if err != nil {
 		return nil, err
 	}
-	log.Debug().Msg("successfully decoded")
+
 	err = c.Validate()
 	if err != nil {
 		return nil, err

--- a/config/chain/optimism.go
+++ b/config/chain/optimism.go
@@ -1,0 +1,59 @@
+package chain
+
+import (
+	"github.com/mitchellh/mapstructure"
+	"github.com/rs/zerolog/log"
+)
+
+const DefaultGasLimit = 6721975
+const DefaultGasPrice = 15000000
+const DefaultGasMultiplier = 1
+const DefaultBlockConfirmations = 10
+
+type OptimismConfig struct {
+	EVMConfig        EVMConfig // Contains configuration of Optimism l2geth client which is used to for sequencing transactions to Optimism
+	VerifyRollup     bool
+	VerifierEndpoint string // This is the endpoint for an Optimism replica which is read-only and used only for verifying transactions
+}
+
+type RawOptimismConfig struct {
+	RawEVMConfig     `mapstructure:",squash"`
+	VerifyRollup     bool   `mapstructure:"verifyRollup"`
+	VerifierEndpoint string `mapstructure:"verifierEndpoint"`
+}
+
+func (c *RawOptimismConfig) Validate() error {
+	if err := c.RawEVMConfig.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewOptimismConfig decodes and validates an instance of an OptimismConfig from
+// raw chain config
+func NewOptimismConfig(chainConfig map[string]interface{}) (*OptimismConfig, error) {
+	log.Debug().Msg("got into optimism config")
+	var c RawOptimismConfig
+	err := mapstructure.Decode(chainConfig, &c)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug().Msg("successfully decoded")
+	err = c.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	evmCfg, err := c.RawEVMConfig.ParseConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	config := &OptimismConfig{
+		EVMConfig:        *evmCfg,
+		VerifyRollup:     c.VerifyRollup,
+		VerifierEndpoint: c.VerifierEndpoint,
+	}
+
+	return config, nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We are moving the logic for the Optimism module back into a separate repository rather than keeping it in the core as this PR does (https://github.com/ChainSafe/chainbridge-core/pull/229). Although Optimism is based on geth, our Optimism chain still needs an extra config field for the verifier endpoint to allow for fast withdrawals as well as some changes to the deploy commands for testing.

## Related Issue Or Context

- The naming for this could perhaps be changed to `OptimisticEVMConfig` or `OptimisticGethConfig`. Optimism is currently the main Optimistic rollup on Ethereum that has directly forked geth. Thus for the Optimism Sequencer we can use our existing EVMConfig to represent the config, and we just need an extra field for selecting whether to verify the rollup and the verifier endpoint itself. This config an future module can be used for an Optimism forks, but perhaps future geth-based Optimistic rollups (however I do not know of any). Arbitrum is the other big EVM Optimistic rollup however they have written their own node and the configuration needed could be different than Optimism. A bit further investigation is needed to decide this. 

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
