### PR TITLE
Pass in eth client inside evm 2 evm test setup

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.43
-          args: -v --timeout 300
+          args: -v --timeout 300s
 
   vet-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.43
-          args: -v
+          args: -v --timeout 300
 
   vet-check:
     runs-on: ubuntu-latest

--- a/chains/evm/cli/local/deploy.go
+++ b/chains/evm/cli/local/deploy.go
@@ -183,7 +183,7 @@ func PrepareErc20EVME2EEnv(
 	bridgeContract *bridge.BridgeContract, erc20Contract *erc20.ERC20Contract, mintTo common.Address, conf EVME2EConfig,
 ) error {
 	// Setting resource
-	resourceID := calls.SliceTo32Bytes(append(common.LeftPadBytes(conf.Erc20Addr.Bytes(), 31), 0))
+	resourceID := calls.SliceTo32Bytes(common.LeftPadBytes([]byte{0}, 31))
 	_, err := bridgeContract.AdminSetResource(
 		conf.Erc20HandlerAddr, resourceID, conf.Erc20Addr, transactor.TransactOptions{GasLimit: 2000000},
 	)
@@ -215,7 +215,7 @@ func PrepareErc20EVME2EEnv(
 }
 
 func PrepareGenericEVME2EEnv(bridgeContract *bridge.BridgeContract, conf EVME2EConfig) error {
-	resourceID := calls.SliceTo32Bytes(append(common.LeftPadBytes(conf.GenericHandlerAddr.Bytes(), 31), 1))
+	resourceID := calls.SliceTo32Bytes(common.LeftPadBytes([]byte{1}, 31))
 	_, err := bridgeContract.AdminSetGenericResource(
 		conf.GenericHandlerAddr,
 		resourceID,
@@ -233,7 +233,7 @@ func PrepareGenericEVME2EEnv(bridgeContract *bridge.BridgeContract, conf EVME2EC
 
 func PrepareErc721EVME2EEnv(bridgeContract *bridge.BridgeContract, erc721Contract *erc721.ERC721Contract, conf EVME2EConfig) error {
 	// Registering resource
-	resourceID := calls.SliceTo32Bytes(append(common.LeftPadBytes(conf.Erc721Addr.Bytes(), 31), uint8(2)))
+	resourceID := calls.SliceTo32Bytes(common.LeftPadBytes([]byte{2}, 31))
 	_, err := bridgeContract.AdminSetResource(conf.Erc721HandlerAddr, resourceID, conf.Erc721Addr, transactor.TransactOptions{GasLimit: 2000000})
 	if err != nil {
 		return err

--- a/chains/evm/cli/local/deploy.go
+++ b/chains/evm/cli/local/deploy.go
@@ -55,13 +55,14 @@ func PrepareLocalEVME2EEnv(
 	domainID uint8,
 	threshold *big.Int,
 	mintTo common.Address,
+	relayerAddresses []common.Address,
 ) (EVME2EConfig, error) {
 	staticGasPricer := evmgaspricer.NewStaticGasPriceDeterminant(ethClient, nil)
 	t := signAndSend.NewSignAndSendTransactor(fabric, staticGasPricer, ethClient)
 
 	bridgeContract := bridge.NewBridgeContract(ethClient, common.Address{}, t)
 	bridgeContractAddress, err := bridgeContract.DeployContract(
-		domainID, DefaultRelayerAddresses, threshold, big.NewInt(0), big.NewInt(100),
+		domainID, relayerAddresses, threshold, big.NewInt(0), big.NewInt(100),
 	)
 	if err != nil {
 		return EVME2EConfig{}, err

--- a/chains/evm/cli/local/local.go
+++ b/chains/evm/cli/local/local.go
@@ -2,9 +2,10 @@ package local
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/ChainSafe/chainbridge-core/chains/evm/calls/evmclient"
 	"github.com/ChainSafe/chainbridge-core/chains/evm/calls/evmtransaction"
-	"math/big"
 
 	"github.com/spf13/cobra"
 )
@@ -39,14 +40,14 @@ func localSetup(cmd *cobra.Command, args []string) error {
 
 	// chain 1
 	// domainsId: 0
-	config, err := PrepareLocalEVME2EEnv(ethClient, fabric1, 1, big.NewInt(1), EveKp.CommonAddress())
+	config, err := PrepareLocalEVME2EEnv(ethClient, fabric1, 1, big.NewInt(1), EveKp.CommonAddress(), DefaultRelayerAddresses)
 	if err != nil {
 		return err
 	}
 
 	// chain 2
 	// domainId: 1
-	config2, err := PrepareLocalEVME2EEnv(ethClient2, fabric2, 2, big.NewInt(1), EveKp.CommonAddress())
+	config2, err := PrepareLocalEVME2EEnv(ethClient2, fabric2, 2, big.NewInt(1), EveKp.CommonAddress(), DefaultRelayerAddresses)
 	if err != nil {
 		return err
 	}
@@ -61,7 +62,7 @@ func prettyPrint(config, config2 EVME2EConfig) {
 ===============================================
 🎉🎉🎉 ChainBridge Successfully Deployed 🎉🎉🎉
 
-- Chain 1 - 
+- Chain 1 -
 Bridge: %s
 ERC20: %s
 ERC20 Handler: %s

--- a/e2e/evm-evm/evm-evm_test.go
+++ b/e2e/evm-evm/evm-evm_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
-	"github.com/ChainSafe/chainbridge-core/chains/evm/calls/evmtransaction"
 	"testing"
+
+	"github.com/ChainSafe/chainbridge-core/chains/evm/calls/evmclient"
+	"github.com/ChainSafe/chainbridge-core/chains/evm/calls/evmtransaction"
 
 	"github.com/ChainSafe/chainbridge-core/chains/evm/cli/local"
 	"github.com/ChainSafe/chainbridge-core/e2e/evm"
@@ -14,5 +16,15 @@ const ETHEndpoint2 = "ws://localhost:8548"
 
 // Alice key is used by the relayer, Eve key is used as admin and depositter
 func TestRunE2ETests(t *testing.T) {
-	suite.Run(t, evm.SetupEVM2EVMTestSuite(evmtransaction.NewTransaction, evmtransaction.NewTransaction, ETHEndpoint1, ETHEndpoint2, local.EveKp))
+	ethClient1, err := evmclient.NewEVMClientFromParams(ETHEndpoint1, local.EveKp.PrivateKey())
+	if err != nil {
+		panic(err)
+	}
+
+	ethClient2, err := evmclient.NewEVMClientFromParams(ETHEndpoint2, local.EveKp.PrivateKey())
+	if err != nil {
+		panic(err)
+	}
+
+	suite.Run(t, evm.SetupEVM2EVMTestSuite(evmtransaction.NewTransaction, evmtransaction.NewTransaction, ethClient1, ethClient2))
 }

--- a/e2e/evm-evm/evm-evm_test.go
+++ b/e2e/evm-evm/evm-evm_test.go
@@ -26,5 +26,15 @@ func TestRunE2ETests(t *testing.T) {
 		panic(err)
 	}
 
-	suite.Run(t, evm.SetupEVM2EVMTestSuite(evmtransaction.NewTransaction, evmtransaction.NewTransaction, ethClient1, ethClient2))
+	suite.Run(
+		t,
+		evm.SetupEVM2EVMTestSuite(
+			evmtransaction.NewTransaction,
+			evmtransaction.NewTransaction,
+			ethClient1,
+			ethClient2,
+			local.DefaultRelayerAddresses,
+			local.DefaultRelayerAddresses,
+		),
+	)
 }

--- a/e2e/evm/test.go
+++ b/e2e/evm/test.go
@@ -138,7 +138,7 @@ func (s *IntegrationTestSuite) TestErc721Deposit() {
 	// This is done here so token only exists on evm1
 	_, err := erc721Contract1.Mint(tokenId, metadata, s.client1.From(), txOptions)
 	s.Nil(err, "Mint failed")
-	_, err = erc721Contract1.Approve(tokenId, s.config2.Erc721HandlerAddr, txOptions)
+	_, err = erc721Contract1.Approve(tokenId, s.config1.Erc721HandlerAddr, txOptions)
 	s.Nil(err, "Approve failed")
 
 	// Check on evm1 if initial owner is admin

--- a/e2e/evm/test.go
+++ b/e2e/evm/test.go
@@ -44,7 +44,8 @@ type IntegrationTestSuite struct {
 	suite.Suite
 	client1    TestClient
 	client2    TestClient
-	gasPricer  calls.GasPricer
+	gasPricer1 calls.GasPricer
+	gasPricer2 calls.GasPricer
 	fabric1    calls.TxFabric
 	fabric2    calls.TxFabric
 	erc20RID   [32]byte
@@ -70,7 +71,8 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.erc20RID = calls.SliceTo32Bytes(common.LeftPadBytes([]byte{0}, 31))
 	s.genericRID = calls.SliceTo32Bytes(common.LeftPadBytes([]byte{1}, 31))
 	s.erc721RID = calls.SliceTo32Bytes(common.LeftPadBytes([]byte{2}, 31))
-	s.gasPricer = evmgaspricer.NewStaticGasPriceDeterminant(s.client2, nil)
+	s.gasPricer1 = evmgaspricer.NewStaticGasPriceDeterminant(s.client1, nil)
+	s.gasPricer2 = evmgaspricer.NewStaticGasPriceDeterminant(s.client2, nil)
 }
 func (s *IntegrationTestSuite) TearDownSuite() {}
 func (s *IntegrationTestSuite) SetupTest()     {}
@@ -79,11 +81,11 @@ func (s *IntegrationTestSuite) TearDownTest()  {}
 func (s *IntegrationTestSuite) TestErc20Deposit() {
 	dstAddr := keystore.TestKeyRing.EthereumKeys[keystore.BobKey].CommonAddress()
 
-	transactor1 := signAndSend.NewSignAndSendTransactor(s.fabric1, s.gasPricer, s.client1)
+	transactor1 := signAndSend.NewSignAndSendTransactor(s.fabric1, s.gasPricer1, s.client1)
 	erc20Contract1 := erc20.NewERC20Contract(s.client1, s.config1.Erc20Addr, transactor1)
 	bridgeContract1 := bridge.NewBridgeContract(s.client1, s.config1.BridgeAddr, transactor1)
 
-	transactor2 := signAndSend.NewSignAndSendTransactor(s.fabric2, s.gasPricer, s.client2)
+	transactor2 := signAndSend.NewSignAndSendTransactor(s.fabric2, s.gasPricer2, s.client2)
 	erc20Contract2 := erc20.NewERC20Contract(s.client2, s.config2.Erc20Addr, transactor2)
 
 	senderBalBefore, err := erc20Contract1.GetBalance(local.EveKp.CommonAddress())
@@ -120,12 +122,12 @@ func (s *IntegrationTestSuite) TestErc721Deposit() {
 	txOptions := transactor.TransactOptions{}
 
 	// erc721 contract for evm1
-	transactor1 := signAndSend.NewSignAndSendTransactor(s.fabric1, s.gasPricer, s.client1)
+	transactor1 := signAndSend.NewSignAndSendTransactor(s.fabric1, s.gasPricer1, s.client1)
 	erc721Contract1 := erc721.NewErc721Contract(s.client1, s.config1.Erc721Addr, transactor1)
 	bridgeContract1 := bridge.NewBridgeContract(s.client1, s.config1.BridgeAddr, transactor1)
 
 	// erc721 contract for evm2
-	transactor2 := signAndSend.NewSignAndSendTransactor(s.fabric2, s.gasPricer, s.client2)
+	transactor2 := signAndSend.NewSignAndSendTransactor(s.fabric2, s.gasPricer2, s.client2)
 	erc721Contract2 := erc721.NewErc721Contract(s.client2, s.config2.Erc721Addr, transactor2)
 
 	// Mint token and give approval
@@ -162,8 +164,8 @@ func (s *IntegrationTestSuite) TestErc721Deposit() {
 }
 
 func (s *IntegrationTestSuite) TestGenericDeposit() {
-	transactor1 := signAndSend.NewSignAndSendTransactor(s.fabric1, s.gasPricer, s.client1)
-	transactor2 := signAndSend.NewSignAndSendTransactor(s.fabric2, s.gasPricer, s.client2)
+	transactor1 := signAndSend.NewSignAndSendTransactor(s.fabric1, s.gasPricer1, s.client1)
+	transactor2 := signAndSend.NewSignAndSendTransactor(s.fabric2, s.gasPricer2, s.client2)
 
 	bridgeContract1 := bridge.NewBridgeContract(s.client1, s.config1.BridgeAddr, transactor1)
 	assetStoreContract2 := centrifuge.NewAssetStoreContract(s.client2, s.config2.AssetStoreAddr, transactor2)

--- a/e2e/evm/test.go
+++ b/e2e/evm/test.go
@@ -31,38 +31,42 @@ type TestClient interface {
 	SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error)
 }
 
-func SetupEVM2EVMTestSuite(fabric1, fabric2 calls.TxFabric, client1, client2 TestClient) *IntegrationTestSuite {
+func SetupEVM2EVMTestSuite(fabric1, fabric2 calls.TxFabric, client1, client2 TestClient, relayerAddresses1, relayerAddresses2 []common.Address) *IntegrationTestSuite {
 	return &IntegrationTestSuite{
-		fabric1: fabric1,
-		fabric2: fabric2,
-		client1: client1,
-		client2: client2,
+		fabric1:           fabric1,
+		fabric2:           fabric2,
+		client1:           client1,
+		client2:           client2,
+		relayerAddresses1: relayerAddresses1,
+		relayerAddresses2: relayerAddresses2,
 	}
 }
 
 type IntegrationTestSuite struct {
 	suite.Suite
-	client1    TestClient
-	client2    TestClient
-	gasPricer1 calls.GasPricer
-	gasPricer2 calls.GasPricer
-	fabric1    calls.TxFabric
-	fabric2    calls.TxFabric
-	erc20RID   [32]byte
-	erc721RID  [32]byte
-	genericRID [32]byte
-	config1    local.EVME2EConfig
-	config2    local.EVME2EConfig
+	relayerAddresses1 []common.Address
+	relayerAddresses2 []common.Address
+	client1           TestClient
+	client2           TestClient
+	gasPricer1        calls.GasPricer
+	gasPricer2        calls.GasPricer
+	fabric1           calls.TxFabric
+	fabric2           calls.TxFabric
+	erc20RID          [32]byte
+	erc721RID         [32]byte
+	genericRID        [32]byte
+	config1           local.EVME2EConfig
+	config2           local.EVME2EConfig
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
-	config1, err := local.PrepareLocalEVME2EEnv(s.client1, s.fabric1, 1, big.NewInt(2), s.client1.From())
+	config1, err := local.PrepareLocalEVME2EEnv(s.client1, s.fabric1, 1, big.NewInt(2), s.client1.From(), s.relayerAddresses1)
 	if err != nil {
 		panic(err)
 	}
 	s.config1 = config1
 
-	config2, err := local.PrepareLocalEVME2EEnv(s.client2, s.fabric2, 2, big.NewInt(2), s.client2.From())
+	config2, err := local.PrepareLocalEVME2EEnv(s.client2, s.fabric2, 2, big.NewInt(2), s.client2.From(), s.relayerAddresses2)
 	if err != nil {
 		panic(err)
 	}

--- a/e2e/evm/test.go
+++ b/e2e/evm/test.go
@@ -154,7 +154,7 @@ func (s *IntegrationTestSuite) TestErc721Deposit() {
 	// Check on evm1 if initial owner is admin
 	initialOwner, err := erc721Contract1.Owner(tokenId)
 	s.Nil(err)
-	s.Equal(initialOwner.String(), s.client1.From())
+	s.Equal(initialOwner.String(), s.client1.From().String())
 
 	// Check on evm2 token doesn't exist
 	_, err = erc721Contract2.Owner(tokenId)

--- a/e2e/evm/test.go
+++ b/e2e/evm/test.go
@@ -82,9 +82,9 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	}
 
 	s.bridgeAddr2 = cfg2.BridgeAddr
-	s.erc20RID = calls.SliceTo32Bytes(append(common.LeftPadBytes(config.Erc20Addr.Bytes(), 31), uint8(0)))
-	s.genericRID = calls.SliceTo32Bytes(append(common.LeftPadBytes(config.GenericHandlerAddr.Bytes(), 31), uint8(1)))
-	s.erc721RID = calls.SliceTo32Bytes(append(common.LeftPadBytes(config.Erc721Addr.Bytes(), 31), uint8(2)))
+	s.erc20RID = calls.SliceTo32Bytes(common.LeftPadBytes([]byte{0}, 31))
+	s.genericRID = calls.SliceTo32Bytes(common.LeftPadBytes([]byte{1}, 31))
+	s.erc721RID = calls.SliceTo32Bytes(common.LeftPadBytes([]byte{2}, 31))
 }
 func (s *IntegrationTestSuite) TearDownSuite() {}
 func (s *IntegrationTestSuite) SetupTest()     {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Trying to create tests inside optimism module there are a couple of problems:
 - resource ids don't match because handler addresses are different (removed handler address from resource id to make always compatible)
 - clients are not injected, but created which makes it annoying as we need to copy/paste setup instead of just injecting instance of `TestCliet` and running tests

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
