### PR TITLE
fix default expiry to 48 hours

### DIFF
--- a/chains/evm/cli/deploy/deploy.go
+++ b/chains/evm/cli/deploy/deploy.go
@@ -45,6 +45,10 @@ var DeployEVM = &cobra.Command{
 	},
 }
 
+const (
+	TwoDaysTermInBlocks int64 = 6200
+)
+
 var (
 	// Flags for all EVM Deploy CLI commands
 	Bridge           bool
@@ -191,7 +195,7 @@ func DeployCLI(cmd *cobra.Command, args []string, txFabric calls.TxFabric, gasPr
 				RelayerAddresses,
 				big.NewInt(0).SetUint64(RelayerThreshold),
 				big.NewInt(0).SetUint64(Fee),
-				big.NewInt(0),
+				big.NewInt(TwoDaysTermInBlocks), // _expiry is set to 48 hours by default
 			)
 			if err != nil {
 				log.Error().Err(fmt.Errorf("bridge deploy failed: %w", err))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

He has kinda bug in CLI
https://github.com/ChainSafe/chainbridge-core/blob/main/chains/evm/cli/deploy/deploy.go#L189
_expiry is set to 0 and there is no way to change it.
It leads to the bug 
https://rinkeby.etherscan.io/address/0x47edbf23bf81c42b3b69af1a4de9bc1ccdacaeca
The first threshold was 1 and everything works fine since the Proposal gets created and executed in one block, so do not have a chance to expire.
But then the threshold has been changed to 2, votes after the first one (in case they are not in the same block) are getting rejected since the proposal is expired.
I do not think that anyone would need to have this value different, so just set it to 48 hours
## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
