### PR TITLE
Generic Deposit CLI command and Generic Resources CLI fixes

### DIFF
--- a/chains/evm/cli/bridge/register-generic-resource.go
+++ b/chains/evm/cli/bridge/register-generic-resource.go
@@ -60,8 +60,8 @@ func BindRegisterGenericResourceFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&ResourceID, "resource", "", "Resource ID to query")
 	cmd.Flags().StringVar(&Bridge, "bridge", "", "Bridge contract address")
 	cmd.Flags().StringVar(&Target, "target", "", "Contract address or hash storage to be registered")
-	cmd.Flags().StringVar(&Deposit, "deposit", "0x00000000", "Deposit function signature")
-	cmd.Flags().StringVar(&Execute, "execute", "0x00000000", "Execute proposal function signature")
+	cmd.Flags().StringVar(&Deposit, "deposit", "00000000", "Deposit function signature")
+	cmd.Flags().StringVar(&Execute, "execute", "00000000", "Execute proposal function signature")
 	cmd.Flags().BoolVar(&Hash, "hash", false, "Treat signature inputs as function prototype strings, hash and take the first 4 bytes")
 	flags.MarkFlagsAsRequired(cmd, "handler", "resource", "bridge", "target")
 }
@@ -103,12 +103,32 @@ func ProcessRegisterGenericResourceFlags(cmd *cobra.Command, args []string) erro
 	ResourceIdBytesArr = callsUtil.SliceTo32Bytes(resourceIdBytes)
 
 	if Hash {
+		// We must check whether both a deposit and execute function signature is provide or else
+		// an invalid hash of 0x00000000 will be taken and set as a function selector in the handler
 		DepositSigBytes = callsUtil.GetSolidityFunctionSig([]byte(Deposit))
 		ExecuteSigBytes = callsUtil.GetSolidityFunctionSig([]byte(Execute))
+		if Deposit == "00000000" {
+			DepositSigBytes = [4]byte{}
+		}
+		if Execute == "00000000" {
+			ExecuteSigBytes = [4]byte{}
+		}
 	} else {
-		copy(DepositSigBytes[:], []byte(Deposit)[:])
-		copy(ExecuteSigBytes[:], []byte(Execute)[:])
+		depositBytes, err := hex.DecodeString(Deposit)
+		if err != nil {
+			panic(err)
+		}
+		copy(DepositSigBytes[:], depositBytes[:])
+
+		executeBytes, err := hex.DecodeString(Execute)
+		if err != nil {
+			panic(err)
+		}
+		copy(ExecuteSigBytes[:], executeBytes[:])
 	}
+
+	log.Debug().Msgf("DepositSigBytes: %x\n", DepositSigBytes[:])
+	log.Debug().Msgf("ExecuteSigBytes: %x\n", ExecuteSigBytes[:])
 
 	return nil
 }
@@ -116,6 +136,13 @@ func ProcessRegisterGenericResourceFlags(cmd *cobra.Command, args []string) erro
 func RegisterGenericResource(cmd *cobra.Command, args []string, contract *bridge.BridgeContract) error {
 	log.Info().Msgf("Registering contract %s with resource ID %s on handler %s", TargetContractAddr, ResourceID, HandlerAddr)
 
+	log.Info().Msgf("handlerAddr: %s, resourceId: %s, targetcontract: %s, depositsigbytes: %s, depositerOffset: %s, executeSigBytes: %s",
+		HandlerAddr,
+		ResourceIdBytesArr,
+		TargetContractAddr,
+		string(DepositSigBytes[:]),
+		big.NewInt(int64(DepositerOffset)),
+		string(DepositSigBytes[:]))
 	h, err := contract.AdminSetGenericResource(
 		HandlerAddr,
 		ResourceIdBytesArr,

--- a/chains/evm/cli/centrifuge/centrifuge.go
+++ b/chains/evm/cli/centrifuge/centrifuge.go
@@ -25,4 +25,5 @@ var CentrifugeCmd = &cobra.Command{
 func init() {
 	CentrifugeCmd.AddCommand(deployCmd)
 	CentrifugeCmd.AddCommand(getHashCmd)
+	CentrifugeCmd.AddCommand(depositCmd)
 }

--- a/chains/evm/cli/centrifuge/deposit.go
+++ b/chains/evm/cli/centrifuge/deposit.go
@@ -1,0 +1,115 @@
+package centrifuge
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ChainSafe/chainbridge-core/chains/evm/calls/contracts/bridge"
+	"github.com/ChainSafe/chainbridge-core/chains/evm/calls/evmtransaction"
+	"github.com/ChainSafe/chainbridge-core/chains/evm/calls/transactor"
+	"github.com/ChainSafe/chainbridge-core/chains/evm/cli/flags"
+	"github.com/ChainSafe/chainbridge-core/chains/evm/cli/initialize"
+	"github.com/ChainSafe/chainbridge-core/chains/evm/cli/logger"
+	"github.com/ChainSafe/chainbridge-core/util"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var depositCmd = &cobra.Command{
+	Use:   "deposit",
+	Short: "Deposit a generic data hash",
+	Long:  "The deposit subcommand creates a new generic data deposit on the bridge contract",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		logger.LoggerMetadata(cmd.Name(), cmd.Flags())
+	},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return util.CallPersistentPreRun(cmd, args)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := initialize.InitializeClient(url, senderKeyPair)
+		if err != nil {
+			return err
+		}
+		t, err := initialize.InitializeTransactor(gasPrice, evmtransaction.NewTransaction, c, prepare)
+		if err != nil {
+			return err
+		}
+		return DepositCmd(cmd, args, bridge.NewBridgeContract(c, BridgeAddr, t))
+	},
+	Args: func(cmd *cobra.Command, args []string) error {
+		err := ValidateDepositFlags(cmd, args)
+		if err != nil {
+			return err
+		}
+
+		err = ProcessDepositFlags(cmd, args)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	BindDepositFlags(depositCmd)
+}
+
+func BindDepositFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&Recipient, "recipient", "", "Address of contract to receive generic data")
+	cmd.Flags().StringVar(&Bridge, "bridge", "", "Address of bridge contract")
+	cmd.Flags().StringVar(&Metadata, "metadata", "", "Piece of data (hex) to transfer")
+	cmd.Flags().Uint8Var(&DomainID, "domain", 0, "Destination domain ID")
+	cmd.Flags().StringVar(&ResourceID, "resource", "", "Resource ID for transfer")
+	cmd.Flags().StringVar(&Priority, "priority", "none", "Transaction priority speed")
+	flags.MarkFlagsAsRequired(cmd, "recipient", "bridge", "metadata", "domain", "resource")
+}
+
+func ValidateDepositFlags(cmd *cobra.Command, args []string) error {
+	if !common.IsHexAddress(Recipient) {
+		return fmt.Errorf("invalid recipient address %s", Recipient)
+	}
+	if !common.IsHexAddress(Bridge) {
+		return fmt.Errorf("invalid bridge address %s", Bridge)
+	}
+	switch Priority {
+	case "none", "slow", "medium", "fast":
+		return nil
+	default:
+		return fmt.Errorf("invalid priority value %s, supported priorities: \"slow|medium|fast\"", Priority)
+	}
+}
+
+func ProcessDepositFlags(cmd *cobra.Command, args []string) error {
+	var err error
+
+	RecipientAddr = common.HexToAddress(Recipient)
+	BridgeAddr = common.HexToAddress(Bridge)
+	ResourceIdBytesArr, err = flags.ProcessResourceID(ResourceID)
+
+	MetadataBytes, err = hex.DecodeString(Metadata)
+	if err != nil {
+		panic(err)
+	}
+
+	return err
+}
+
+func DepositCmd(cmd *cobra.Command, args []string, bridgeContract *bridge.BridgeContract) error {
+	txHash, err := bridgeContract.GenericDeposit(
+		[]byte(Metadata), ResourceIdBytesArr, uint8(DomainID), transactor.TransactOptions{GasLimit: gasLimit, Priority: transactor.TxPriorities[Priority]},
+	)
+	if err != nil {
+		return err
+	}
+
+	log.Info().Msgf(
+		`Generic deposit hash: %s
+		%s metadata was transferred to %s from %s`,
+		txHash.Hex(),
+		Metadata,
+		RecipientAddr.Hex(),
+		senderKeyPair.CommonAddress().String(),
+	)
+	return nil
+}

--- a/chains/evm/cli/centrifuge/flagVars.go
+++ b/chains/evm/cli/centrifuge/flagVars.go
@@ -4,25 +4,37 @@ import (
 	"math/big"
 
 	"github.com/ChainSafe/chainbridge-core/crypto/secp256k1"
+	"github.com/ChainSafe/chainbridge-core/types"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 //flag vars
 var (
-	Hash    string
-	Address string
+	Hash       string
+	Address    string
+	Metadata   string
+	Recipient  string
+	Bridge     string
+	DomainID   uint8
+	ResourceID string
+	Priority   string
 )
 
 //processed flag vars
 var (
-	StoreAddr common.Address
-	ByteHash  [32]byte
+	StoreAddr          common.Address
+	ByteHash           [32]byte
+	MetadataBytes      []byte
+	RecipientAddr      common.Address
+	BridgeAddr         common.Address
+	ResourceIdBytesArr types.ResourceID
 )
 
 // global flags
 var (
 	url           string
 	gasPrice      *big.Int
+	gasLimit      uint64
 	senderKeyPair *secp256k1.Keypair
 	prepare       bool
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There is currently no CLI deposit method for bridging with the generic handler on the EVM side of the bridge. This PR adds a deposit command to the centrifuge CLI for depositing generic data on the bridge. 

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

While testing this method an error was discovered in the `register-generic-resource` method.  Using `copy(DepositSignatureBytes[:], []byte(DepositSignatureString)[:])` does not directly convert the hex string into the hex representation in bytes. Rather the string is transformed into its hex values. For example `0x00000000` will be encoded into `30783030`. 

On top of this, we are also currently hashing both functions when `--hash` is specified and not checking if one function is still its default value of `bytes4(0)`. This results in an incorrect function signature being registered (bytes4(keccack256(00000000))).

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
