### PR TITLE
Fix parsing sender address of deposit event

### DIFF
--- a/chains/evm/calls/evmclient/evm-client.go
+++ b/chains/evm/calls/evmclient/evm-client.go
@@ -180,6 +180,8 @@ func (c *EVMClient) FetchDepositLogs(ctx context.Context, contractAddress common
 			log.Error().Msgf("failed unpacking deposit event log: %v", err)
 			continue
 		}
+
+		dl.SenderAddress = common.BytesToAddress(l.Topics[1].Bytes())
 		log.Debug().Msgf("Found deposit log in block: %d, TxHash: %s, contractAddress: %s, sender: %s", l.BlockNumber, l.TxHash, l.Address, dl.SenderAddress)
 
 		depositLogs = append(depositLogs, dl)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As the `user` field is indexed, it's located in `eventLog.Topics` instead of `eventLog.Data`
```
    event Deposit(
        uint8 destinationDomainID,
        bytes32 resourceID,
        uint64 depositNonce,
        address indexed user,
        bytes data,
        bytes handlerResponse
    );
```
## Related Issue Or Context

In the relayer the Sender address is always `address(0)`


## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
