### PR TITLE
Refactor listener so it allows listening to multiple blocks of events

### DIFF
--- a/chains/evm/chain.go
+++ b/chains/evm/chain.go
@@ -15,7 +15,7 @@ import (
 )
 
 type EventListener interface {
-	ListenToEvents(ctx context.Context, startBlock *big.Int, msgChan chan *message.Message, errChan chan<- error)
+	ListenToEvents(ctx context.Context, startBlock *big.Int, msgChan chan []*message.Message, errChan chan<- error)
 }
 
 type ProposalExecutor interface {
@@ -36,7 +36,7 @@ func NewEVMChain(listener EventListener, writer ProposalExecutor, blockstore *st
 
 // PollEvents is the goroutine that polls blocks and searches Deposit events in them.
 // Events are then sent to eventsChan.
-func (c *EVMChain) PollEvents(ctx context.Context, sysErr chan<- error, msgChan chan *message.Message) {
+func (c *EVMChain) PollEvents(ctx context.Context, sysErr chan<- error, msgChan chan []*message.Message) {
 	log.Info().Msg("Polling Blocks...")
 
 	startBlock, err := c.blockstore.GetStartBlock(
@@ -53,8 +53,10 @@ func (c *EVMChain) PollEvents(ctx context.Context, sysErr chan<- error, msgChan 
 	go c.listener.ListenToEvents(ctx, startBlock, msgChan, sysErr)
 }
 
-func (c *EVMChain) Write(msg *message.Message) error {
-	return c.writer.Execute(msg)
+func (c *EVMChain) Write(msg []*message.Message) {
+	for _, msg := range msg {
+		go c.writer.Execute(msg)
+	}
 }
 
 func (c *EVMChain) DomainID() uint8 {

--- a/chains/evm/chain.go
+++ b/chains/evm/chain.go
@@ -55,7 +55,12 @@ func (c *EVMChain) PollEvents(ctx context.Context, sysErr chan<- error, msgChan 
 
 func (c *EVMChain) Write(msg []*message.Message) {
 	for _, msg := range msg {
-		go c.writer.Execute(msg)
+		go func(msg *message.Message) {
+			err := c.writer.Execute(msg)
+			if err != nil {
+				log.Err(err).Msgf("Failed writing message %v", msg)
+			}
+		}(msg)
 	}
 }
 

--- a/chains/evm/executor/voter.go
+++ b/chains/evm/executor/voter.go
@@ -110,6 +110,7 @@ func (v *EVMVoter) Execute(m *message.Message) error {
 
 	votedByTheRelayer, err := v.bridgeContract.IsProposalVotedBy(v.client.RelayerAddress(), prop)
 	if err != nil {
+		log.Error().Err(err).Msgf("Fetching is proposal %v voted by relayer failed", prop)
 		return err
 	}
 	if votedByTheRelayer {
@@ -118,7 +119,7 @@ func (v *EVMVoter) Execute(m *message.Message) error {
 
 	shouldVote, err := v.shouldVoteForProposal(prop, 0)
 	if err != nil {
-		log.Error().Err(err)
+		log.Error().Err(err).Msgf("Should vote for proposal %v failed", prop)
 		return err
 	}
 
@@ -128,12 +129,13 @@ func (v *EVMVoter) Execute(m *message.Message) error {
 	}
 	err = v.repetitiveSimulateVote(prop, 0)
 	if err != nil {
-		log.Error().Err(err)
+		log.Error().Err(err).Msgf("Simulating proposal %+v vote failed", prop)
 		return err
 	}
 
 	hash, err := v.bridgeContract.VoteProposal(prop, transactor.TransactOptions{Priority: prop.Metadata.Priority})
 	if err != nil {
+		log.Error().Err(err).Msgf("voting for proposal %+v failed", prop)
 		return fmt.Errorf("voting failed. Err: %w", err)
 	}
 

--- a/chains/evm/listener/listener.go
+++ b/chains/evm/listener/listener.go
@@ -16,7 +16,7 @@ import (
 )
 
 type EventHandler interface {
-	HandleEvent(block *big.Int, msgChan chan *message.Message) error
+	HandleEvent(startBlock *big.Int, endBlock *big.Int, msgChan chan []*message.Message) error
 }
 
 type ChainClient interface {
@@ -31,6 +31,7 @@ type EVMListener struct {
 	blockstore         *store.BlockStore
 	blockRetryInterval time.Duration
 	blockConfirmations *big.Int
+	blockInterval      *big.Int
 }
 
 // NewEVMListener creates an EVMListener that listens to deposit events on chain
@@ -43,12 +44,14 @@ func NewEVMListener(client ChainClient, eventHandlers []EventHandler, blockstore
 		domainID:           *config.GeneralChainConfig.Id,
 		blockRetryInterval: config.BlockRetryInterval,
 		blockConfirmations: config.BlockConfirmations,
+		blockInterval:      config.BlockInterval,
 	}
 }
 
 // ListenToEvents goes block by block of a network and executes event handlers that are
 // configured for the listener.
-func (l *EVMListener) ListenToEvents(ctx context.Context, block *big.Int, msgChan chan *message.Message, errChn chan<- error) {
+func (l *EVMListener) ListenToEvents(ctx context.Context, startBlock *big.Int, msgChan chan []*message.Message, errChn chan<- error) {
+	endBlock := big.NewInt(0)
 	for {
 		select {
 		case <-ctx.Done():
@@ -60,17 +63,19 @@ func (l *EVMListener) ListenToEvents(ctx context.Context, block *big.Int, msgCha
 				time.Sleep(l.blockRetryInterval)
 				continue
 			}
-			if block == nil {
-				block = head
+			if startBlock == nil {
+				startBlock = head
 			}
+			endBlock.Add(startBlock, l.blockInterval)
+
 			// Sleep if the difference is less than needed block confirmations; (latest - current) < BlockDelay
-			if big.NewInt(0).Sub(head, block).Cmp(l.blockConfirmations) == -1 {
+			if big.NewInt(0).Sub(head, endBlock).Cmp(l.blockConfirmations) == -1 {
 				time.Sleep(l.blockRetryInterval)
 				continue
 			}
 
 			for _, handler := range l.eventHandlers {
-				err := handler.HandleEvent(block, msgChan)
+				err := handler.HandleEvent(startBlock, endBlock, msgChan)
 				if err != nil {
 					log.Error().Err(err).Str("DomainID", string(l.domainID)).Msgf("Unable to handle events")
 					continue
@@ -78,11 +83,11 @@ func (l *EVMListener) ListenToEvents(ctx context.Context, block *big.Int, msgCha
 			}
 
 			//Write to block store. Not a critical operation, no need to retry
-			err = l.blockstore.StoreBlock(block, l.domainID)
+			err = l.blockstore.StoreBlock(endBlock, l.domainID)
 			if err != nil {
-				log.Error().Str("block", block.String()).Err(err).Msg("Failed to write latest block to blockstore")
+				log.Error().Str("block", endBlock.String()).Err(err).Msg("Failed to write latest block to blockstore")
 			}
-			block.Add(block, big.NewInt(1))
+			startBlock.Add(startBlock, l.blockInterval)
 		}
 	}
 }

--- a/config/chain/evm.go
+++ b/config/chain/evm.go
@@ -2,9 +2,10 @@ package chain
 
 import (
 	"fmt"
-	"github.com/creasty/defaults"
 	"math/big"
 	"time"
+
+	"github.com/creasty/defaults"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -20,6 +21,7 @@ type EVMConfig struct {
 	GasLimit           *big.Int
 	StartBlock         *big.Int
 	BlockConfirmations *big.Int
+	BlockInterval      *big.Int
 	BlockRetryInterval time.Duration
 }
 
@@ -34,6 +36,7 @@ type RawEVMConfig struct {
 	GasLimit           int64   `mapstructure:"gasLimit" default:"2000000"`
 	StartBlock         int64   `mapstructure:"startBlock"`
 	BlockConfirmations int64   `mapstructure:"blockConfirmations" default:"10"`
+	BlockInterval      int64   `mapstructure:"blockInterval" default:"5"`
 	BlockRetryInterval uint64  `mapstructure:"blockRetryInterval" default:"5"`
 }
 
@@ -82,6 +85,7 @@ func NewEVMConfig(chainConfig map[string]interface{}) (*EVMConfig, error) {
 		GasMultiplier:      big.NewFloat(c.GasMultiplier),
 		StartBlock:         big.NewInt(c.StartBlock),
 		BlockConfirmations: big.NewInt(c.BlockConfirmations),
+		BlockInterval:      big.NewInt(c.BlockInterval),
 	}
 
 	return config, nil

--- a/config/chain/evm_test.go
+++ b/config/chain/evm_test.go
@@ -90,6 +90,7 @@ func (s *NewEVMConfigTestSuite) Test_ValidConfig() {
 		GasMultiplier:      big.NewFloat(1),
 		StartBlock:         big.NewInt(0),
 		BlockConfirmations: big.NewInt(10),
+		BlockInterval:      big.NewInt(5),
 		BlockRetryInterval: time.Duration(5) * time.Second,
 	})
 }
@@ -107,6 +108,7 @@ func (s *NewEVMConfigTestSuite) Test_ValidConfigWithCustomTxParams() {
 		"startBlock":         1000,
 		"blockConfirmations": 10,
 		"blockRetryInterval": 10,
+		"blockInterval":      2,
 	}
 
 	actualConfig, err := chain.NewEVMConfig(rawConfig)
@@ -129,6 +131,7 @@ func (s *NewEVMConfigTestSuite) Test_ValidConfigWithCustomTxParams() {
 		GasMultiplier:      big.NewFloat(1000),
 		StartBlock:         big.NewInt(1000),
 		BlockConfirmations: big.NewInt(10),
+		BlockInterval:      big.NewInt(2),
 		BlockRetryInterval: time.Duration(10) * time.Second,
 	})
 }

--- a/example/cfg/config_evm-evm_1.json
+++ b/example/cfg/config_evm-evm_1.json
@@ -14,6 +14,7 @@
       "gasLimit": 9000000,
       "maxGasPrice": 20000000000,
       "blockConfirmations": 2,
+      "blockInterval": 2,
       "key": "000000000000000000000000000000000000000000000000000000616c696365"
     },
     {
@@ -29,6 +30,7 @@
       "gasLimit": 9000000,
       "maxGasPrice": 20000000000,
       "blockConfirmations": 2,
+      "blockInterval": 2,
       "key": "000000000000000000000000000000000000000000000000000000616c696365"
     }
   ]

--- a/relayer/mock/relayer.go
+++ b/relayer/mock/relayer.go
@@ -85,7 +85,7 @@ func (mr *MockRelayedChainMockRecorder) DomainID() *gomock.Call {
 }
 
 // PollEvents mocks base method.
-func (m *MockRelayedChain) PollEvents(ctx context.Context, sysErr chan<- error, msgChan chan *message.Message) {
+func (m *MockRelayedChain) PollEvents(ctx context.Context, sysErr chan<- error, msgChan chan []*message.Message) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "PollEvents", ctx, sysErr, msgChan)
 }
@@ -97,15 +97,13 @@ func (mr *MockRelayedChainMockRecorder) PollEvents(ctx, sysErr, msgChan interfac
 }
 
 // Write mocks base method.
-func (m *MockRelayedChain) Write(message *message.Message) error {
+func (m *MockRelayedChain) Write(messages []*message.Message) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Write", message)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "Write", messages)
 }
 
 // Write indicates an expected call of Write.
-func (mr *MockRelayedChainMockRecorder) Write(message interface{}) *gomock.Call {
+func (mr *MockRelayedChainMockRecorder) Write(messages interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockRelayedChain)(nil).Write), message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockRelayedChain)(nil).Write), messages)
 }

--- a/relayer/relayer_test.go
+++ b/relayer/relayer_test.go
@@ -31,12 +31,13 @@ func (s *RouteTestSuite) SetupTest() {
 func (s *RouteTestSuite) TearDownTest() {}
 
 func (s *RouteTestSuite) TestLogsErrorIfDestinationDoesNotExist() {
-	s.mockMetrics.EXPECT().TrackDepositMessage(gomock.Any())
 	relayer := Relayer{
 		metrics: s.mockMetrics,
 	}
 
-	relayer.route(&message.Message{})
+	relayer.route([]*message.Message{
+		{},
+	})
 }
 
 // TestRouter tests relayers router
@@ -68,31 +69,15 @@ func (s *RouteTestSuite) TestLogsErrorIfMessageProcessorReturnsError() {
 	)
 	relayer.addRelayedChain(s.mockRelayedChain)
 
-	relayer.route(&message.Message{
-		Destination: 1,
-	})
-}
-
-func (s *RouteTestSuite) TestLogsErrorIfWriteReturnsError() {
-	s.mockMetrics.EXPECT().TrackDepositMessage(gomock.Any())
-	s.mockRelayedChain.EXPECT().DomainID().Return(uint8(1))
-	s.mockRelayedChain.EXPECT().Write(gomock.Any()).Return(fmt.Errorf("Error"))
-	relayer := NewRelayer(
-		[]RelayedChain{},
-		s.mockMetrics,
-		func(m *message.Message) error { return nil },
-	)
-	relayer.addRelayedChain(s.mockRelayedChain)
-
-	relayer.route(&message.Message{
-		Destination: 1,
+	relayer.route([]*message.Message{
+		{Destination: 1},
 	})
 }
 
 func (s *RouteTestSuite) TestWritesToDestChainIfMessageValid() {
 	s.mockMetrics.EXPECT().TrackDepositMessage(gomock.Any())
-	s.mockRelayedChain.EXPECT().DomainID().Return(uint8(1))
-	s.mockRelayedChain.EXPECT().Write(gomock.Any()).Return(nil)
+	s.mockRelayedChain.EXPECT().DomainID().Return(uint8(1)).Times(2)
+	s.mockRelayedChain.EXPECT().Write(gomock.Any())
 	relayer := NewRelayer(
 		[]RelayedChain{},
 		s.mockMetrics,
@@ -100,7 +85,7 @@ func (s *RouteTestSuite) TestWritesToDestChainIfMessageValid() {
 	)
 	relayer.addRelayedChain(s.mockRelayedChain)
 
-	relayer.route(&message.Message{
-		Destination: 1,
+	relayer.route([]*message.Message{
+		{Destination: 1},
 	})
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We want to be able to configure batches of events to be listened to instead of hardcoding listening to 1 block per request.
This PR refactors listener so it allows for configurable amount of blocks to be checked at once and allows for execution batching as it sends an array of messages to the writer.

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
