### PR TITLE
sign transactions using a signer interface instead of a private key

### DIFF
--- a/chains/evm/calls/evmtransaction/evm-tx_test.go
+++ b/chains/evm/calls/evmtransaction/evm-tx_test.go
@@ -7,8 +7,9 @@ import (
 	evmgaspricer "github.com/ChainSafe/chainbridge-core/chains/evm/calls/evmgaspricer"
 	mock_evmgaspricer "github.com/ChainSafe/chainbridge-core/chains/evm/calls/evmgaspricer/mock"
 
-	"github.com/ChainSafe/chainbridge-core/keystore"
 	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ChainSafe/chainbridge-core/keystore"
 
 	"github.com/ethereum/go-ethereum/common"
 

--- a/chains/evm/calls/evmtransaction/evm-tx_test.go
+++ b/chains/evm/calls/evmtransaction/evm-tx_test.go
@@ -43,7 +43,7 @@ func (s *EVMTxTestSuite) TestNewTransactionWithStaticGasPricer() {
 	s.Nil(err)
 	tx, err := txFabric(1, &common.Address{}, big.NewInt(0), 10000, gp, []byte{})
 	s.Nil(err)
-	rawTx, err := tx.RawWithSignature(aliceKp.PrivateKey(), big.NewInt(420))
+	rawTx, err := tx.RawWithSignature(aliceKp, big.NewInt(420))
 	s.Nil(err)
 	txt := types.Transaction{}
 	err = txt.UnmarshalBinary(rawTx)
@@ -60,7 +60,7 @@ func (s *EVMTxTestSuite) TestNewTransactionWithLondonGasPricer() {
 	s.Nil(err)
 	tx, err := txFabric(1, &common.Address{}, big.NewInt(0), 10000, gp, []byte{})
 	s.Nil(err)
-	rawTx, err := tx.RawWithSignature(aliceKp.PrivateKey(), big.NewInt(420))
+	rawTx, err := tx.RawWithSignature(aliceKp, big.NewInt(420))
 	s.Nil(err)
 	txt := types.Transaction{}
 	err = txt.UnmarshalBinary(rawTx)

--- a/chains/evm/calls/transactor/itx/mock/itx.go
+++ b/chains/evm/calls/transactor/itx/mock/itx.go
@@ -172,3 +172,55 @@ func (mr *MockForwarderMockRecorder) UnsafeNonce() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnsafeNonce", reflect.TypeOf((*MockForwarder)(nil).UnsafeNonce))
 }
+
+// MockSigner is a mock of Signer interface.
+type MockSigner struct {
+	ctrl     *gomock.Controller
+	recorder *MockSignerMockRecorder
+}
+
+// MockSignerMockRecorder is the mock recorder for MockSigner.
+type MockSignerMockRecorder struct {
+	mock *MockSigner
+}
+
+// NewMockSigner creates a new mock instance.
+func NewMockSigner(ctrl *gomock.Controller) *MockSigner {
+	mock := &MockSigner{ctrl: ctrl}
+	mock.recorder = &MockSignerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSigner) EXPECT() *MockSignerMockRecorder {
+	return m.recorder
+}
+
+// CommonAddress mocks base method.
+func (m *MockSigner) CommonAddress() common.Address {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CommonAddress")
+	ret0, _ := ret[0].(common.Address)
+	return ret0
+}
+
+// CommonAddress indicates an expected call of CommonAddress.
+func (mr *MockSignerMockRecorder) CommonAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommonAddress", reflect.TypeOf((*MockSigner)(nil).CommonAddress))
+}
+
+// Sign mocks base method.
+func (m *MockSigner) Sign(digestHash []byte) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Sign", digestHash)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Sign indicates an expected call of Sign.
+func (mr *MockSignerMockRecorder) Sign(digestHash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockSigner)(nil).Sign), digestHash)
+}

--- a/chains/evm/cli/deploy/deploy.go
+++ b/chains/evm/cli/deploy/deploy.go
@@ -172,7 +172,7 @@ func DeployCLI(cmd *cobra.Command, args []string, txFabric calls.TxFabric, gasPr
 	log.Debug().Msgf("url: %s gas limit: %v gas price: %v", url, gasLimit, gasPrice)
 	log.Debug().Msgf("SENDER Private key 0x%s", hex.EncodeToString(crypto.FromECDSA(senderKeyPair.PrivateKey())))
 
-	ethClient, err := evmclient.NewEVMClient(url, senderKeyPair.PrivateKey())
+	ethClient, err := evmclient.NewEVMClient(url, senderKeyPair)
 	if err != nil {
 		log.Error().Err(fmt.Errorf("ethereum client error: %v", err)).Msg("error initializing new EVM client")
 		return err

--- a/chains/evm/cli/deploy/deploy.go
+++ b/chains/evm/cli/deploy/deploy.go
@@ -1,7 +1,6 @@
 package deploy
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -20,7 +19,6 @@ import (
 	"github.com/ChainSafe/chainbridge-core/chains/evm/cli/logger"
 	"github.com/ChainSafe/chainbridge-core/chains/evm/cli/utils"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -170,7 +168,7 @@ func DeployCLI(cmd *cobra.Command, args []string, txFabric calls.TxFabric, gasPr
 	}
 
 	log.Debug().Msgf("url: %s gas limit: %v gas price: %v", url, gasLimit, gasPrice)
-	log.Debug().Msgf("SENDER Private key 0x%s", hex.EncodeToString(crypto.FromECDSA(senderKeyPair.PrivateKey())))
+	log.Debug().Msgf("SENDER Address %s", senderKeyPair.CommonAddress().Hex())
 
 	ethClient, err := evmclient.NewEVMClient(url, senderKeyPair)
 	if err != nil {

--- a/chains/evm/cli/initialize/initialize.go
+++ b/chains/evm/cli/initialize/initialize.go
@@ -18,8 +18,7 @@ func InitializeClient(
 	url string,
 	senderKeyPair *secp256k1.Keypair,
 ) (*evmclient.EVMClient, error) {
-	ethClient, err := evmclient.NewEVMClient(
-		url, senderKeyPair.PrivateKey())
+	ethClient, err := evmclient.NewEVMClient(url, senderKeyPair)
 	if err != nil {
 		log.Error().Err(fmt.Errorf("eth client initialization error: %v", err))
 		return nil, err

--- a/chains/evm/cli/local/local.go
+++ b/chains/evm/cli/local/local.go
@@ -36,13 +36,13 @@ func init() {
 
 func localSetup(cmd *cobra.Command, args []string) error {
 	// init client1
-	ethClient, err := evmclient.NewEVMClient(ethEndpoint1, EveKp.PrivateKey())
+	ethClient, err := evmclient.NewEVMClient(ethEndpoint1, EveKp)
 	if err != nil {
 		return err
 	}
 
 	// init client2
-	ethClient2, err := evmclient.NewEVMClient(ethEndpoint2, EveKp.PrivateKey())
+	ethClient2, err := evmclient.NewEVMClient(ethEndpoint2, EveKp)
 	if err != nil {
 		return err
 	}

--- a/chains/evm/cli/utils/hash-list.go
+++ b/chains/evm/cli/utils/hash-list.go
@@ -43,7 +43,7 @@ func HashListCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not get global flags: %v", err)
 	}
 
-	ethClient, err := evmclient.NewEVMClient(url, senderKeyPair.PrivateKey())
+	ethClient, err := evmclient.NewEVMClient(url, senderKeyPair)
 	if err != nil {
 		log.Error().Err(fmt.Errorf("eth client intialization error: %v", err))
 		return err

--- a/chains/evm/cli/utils/simulate.go
+++ b/chains/evm/cli/utils/simulate.go
@@ -80,7 +80,7 @@ Block number: %v
 From address: %s`,
 		TxHash, blockNumberBigInt, FromAddress)
 
-	ethClient, err := evmclient.NewEVMClient(url, senderKeyPair.PrivateKey())
+	ethClient, err := evmclient.NewEVMClient(url, senderKeyPair)
 	if err != nil {
 		log.Error().Err(fmt.Errorf("eth client intialization error: %v", err))
 		return err

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	secp256k1 "github.com/ethereum/go-ethereum/crypto"
 )
@@ -99,4 +100,10 @@ func (kp *Keypair) PublicKey() string {
 // PrivateKey returns the keypair's private key
 func (kp *Keypair) PrivateKey() *ecdsa.PrivateKey {
 	return kp.private
+}
+
+// Sign calculates an ECDSA signature.
+// The produced signature is in the [R || S || V] format where V is 0 or 1.
+func (kp *Keypair) Sign(digestHash []byte) ([]byte, error) {
+	return crypto.Sign(digestHash, kp.private)
 }

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -97,11 +97,6 @@ func (kp *Keypair) PublicKey() string {
 	return hexutil.Encode(secp256k1.CompressPubkey(kp.public))
 }
 
-// PrivateKey returns the keypair's private key
-func (kp *Keypair) PrivateKey() *ecdsa.PrivateKey {
-	return kp.private
-}
-
 // Sign calculates an ECDSA signature.
 // The produced signature is in the [R || S || V] format where V is 0 or 1.
 func (kp *Keypair) Sign(digestHash []byte) ([]byte, error) {

--- a/crypto/secp256k1/secp256k1_test.go
+++ b/crypto/secp256k1/secp256k1_test.go
@@ -4,8 +4,12 @@
 package secp256k1
 
 import (
+	"crypto/sha256"
+	"math/big"
 	"reflect"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func TestNewKeypairFromSeed(t *testing.T) {
@@ -34,5 +38,33 @@ func TestEncodeAndDecodeKeypair(t *testing.T) {
 
 	if !reflect.DeepEqual(res, kp) {
 		t.Fatalf("Fail: got %#v expected %#v", res, kp)
+	}
+}
+
+func TestSign(t *testing.T) {
+	kp, err := GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digestHash := sha256.Sum256([]byte{0, 0})
+
+	sig, err := kp.Sign(digestHash[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(sig) != crypto.SignatureLength {
+		t.Fatalf("Fail: wrong size for signature: got %d, want %d", len(sig), crypto.SignatureLength)
+	}
+
+	r := new(big.Int).SetBytes(sig[:32])
+	s := new(big.Int).SetBytes(sig[32:64])
+	v := sig[64]
+
+	valid := crypto.ValidateSignatureValues(v, r, s, true)
+
+	if !valid {
+		t.Fatal("Fail: got invalid signature")
 	}
 }

--- a/e2e/evm/evm_test.go
+++ b/e2e/evm/evm_test.go
@@ -57,13 +57,13 @@ func Test_EVM2EVM(t *testing.T) {
 		AssetStoreAddr:     common.HexToAddress("0x3cA3808176Ad060Ad80c4e08F30d85973Ef1d99e"),
 	}
 
-	ethClient1, err := evmclient.NewEVMClient(ETHEndpoint1, local.EveKp.PrivateKey())
+	ethClient1, err := evmclient.NewEVMClient(ETHEndpoint1, local.EveKp)
 	if err != nil {
 		panic(err)
 	}
 	gasPricer1 := dummy.NewStaticGasPriceDeterminant(ethClient1, nil)
 
-	ethClient2, err := evmclient.NewEVMClient(ETHEndpoint2, local.EveKp.PrivateKey())
+	ethClient2, err := evmclient.NewEVMClient(ETHEndpoint2, local.EveKp)
 	if err != nil {
 		panic(err)
 	}
@@ -158,7 +158,7 @@ func (s *IntegrationTestSuite) Test_Erc20Deposit() {
 
 	destBalanceAfter, err := erc20Contract2.GetBalance(dstAddr)
 	s.Nil(err)
-	//Balance has increased
+	// Balance has increased
 	s.Equal(1, destBalanceAfter.Cmp(destBalanceBefore))
 }
 

--- a/example/app/app.go
+++ b/example/app/app.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ChainSafe/chainbridge-core/chains/evm/listener"
 	"github.com/ChainSafe/chainbridge-core/config"
 	"github.com/ChainSafe/chainbridge-core/config/chain"
+	secp256k12 "github.com/ChainSafe/chainbridge-core/crypto/secp256k1"
 	"github.com/ChainSafe/chainbridge-core/e2e/dummy"
 	"github.com/ChainSafe/chainbridge-core/flags"
 	"github.com/ChainSafe/chainbridge-core/lvldb"
@@ -60,7 +61,9 @@ func Run() error {
 					panic(err)
 				}
 
-				client, err := evmclient.NewEVMClient(config.GeneralChainConfig.Endpoint, privateKey)
+				kp := secp256k12.NewKeypair(*privateKey)
+
+				client, err := evmclient.NewEVMClient(config.GeneralChainConfig.Endpoint, kp)
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sign transactions using a signer interface instead of a private key. This will allow to use custom singers such as a remote signer.

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change here -->
We are experimenting with your repo and the only problem we are facing right now is that one of our requirements is using a remote signer.
With this changes a custom signer could be implemented and passed down to evmclient to sign transactions without the need of a private key.

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
provided unit tests and local setup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
