### PR TITLE
add blurb to declare the migration of CB core to sygma core

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 
 &nbsp;
 
+# Migration Notice 
+Please note the Chainbridge-Core repo will be migrated to Sygma-Core as part of ongoing work to update the codebase. See [Sygma](https://github.com/sygmaprotocol) to learn more.
+
 Chainbridge-Core was born from and built to improve the maintainability and modularity of the existing version of [ChainBridge](https://github.com/ChainSafe/chainbridge). The fundamental distinction between the two is that Chainbridge-Core is more of a framework rather than a stand-alone application.
 
 &nbsp;


### PR DESCRIPTION
## Description
per request from @itsbobbyzzz168 and @alexmmueller, adding a tiny blurb to notify devs of migration of chainbridge-core to sygma-core, which will be done by @mpetrun5 soon.

## Related Issue Or Context
@itsbobbyzzz168 noticed "chainbridge" repo is referenced in snowbridge's proposal. @itsbobbyzzz168 also mentions the chainbridge-core repo is mentioned in his newest treasury proposal. we want to mention sygma to show that work is ongoing and that the repo is still in active development. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
